### PR TITLE
fix: coalesce sub-8 KiB GetObject chunks before streaming to UploadPart

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -3,6 +3,7 @@
     "biomejs",
     "deque",
     "floci",
+    "imds",
     "localstack",
     "pnpm",
     "shuntaka",

--- a/lib/s3/client.ts
+++ b/lib/s3/client.ts
@@ -67,6 +67,14 @@ export const getListFiles = async (
 const encodeCopySourceKey = (key: string): string =>
   key.split('/').map(encodeURIComponent).join('/');
 
+// S3's SigV4 chunked transfer encoding requires every non-final chunk to be
+// at least 8192 bytes. GetObject bodies of small source files can yield
+// chunks well below that, which makes UploadPartCommand fail with
+// InvalidChunkSizeError against real S3 (LocalStack/floci don't enforce it).
+// Coalesce yielded buffers up to MIN_STREAM_CHUNK before passing them on;
+// the very last chunk is allowed to be smaller and is flushed at the end.
+const MIN_STREAM_CHUNK = 64 * 1024;
+
 const createCombinedStream = (
   s3Client: S3Client,
   s3Files: S3File[],
@@ -74,6 +82,9 @@ const createCombinedStream = (
 ): Readable =>
   Readable.from(
     (async function* () {
+      const pending: Buffer[] = [];
+      let pendingSize = 0;
+
       for (const f of s3Files) {
         const range = `bytes=${f.start}-${f.size - 1}`;
         const getRes = await s3Client.send(
@@ -89,8 +100,18 @@ const createCombinedStream = (
           throw new Error(`empty body for s3://${bucketName}/${f.key}`);
         }
         for await (const chunk of body as Readable) {
-          yield chunk;
+          const buf = chunk as Buffer;
+          pending.push(buf);
+          pendingSize += buf.length;
+          if (pendingSize >= MIN_STREAM_CHUNK) {
+            yield Buffer.concat(pending, pendingSize);
+            pending.length = 0;
+            pendingSize = 0;
+          }
         }
+      }
+      if (pendingSize > 0) {
+        yield Buffer.concat(pending, pendingSize);
       }
     })()
   );

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "check:spell": "cspell lint . --cache --gitignore",
     "clean": "rimraf dist",
     "test": "vitest run --config vitest.config.ts --coverage.enabled true --reporter=verbose",
+    "e2e": "USE_REAL_S3=1 vitest run --config vitest.config.ts --reporter=verbose",
     "publish": "semantic-release"
   },
   "author": "shuntaka9576",
@@ -35,7 +36,7 @@
     "@aws-sdk/client-s3": "^3.0.0"
   },
   "devDependencies": {
-    "@aws-sdk/client-s3": "3.726.0",
+    "@aws-sdk/client-s3": "3.1070.0",
     "@biomejs/biome": "1.9.4",
     "@floci/testcontainers": "0.1.0",
     "@vitest/coverage-v8": "3.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
         version: 6.2.0
     devDependencies:
       '@aws-sdk/client-s3':
-        specifier: 3.726.0
-        version: 3.726.0
+        specifier: 3.1070.0
+        version: 3.1070.0
       '@biomejs/biome':
         specifier: 1.9.4
         version: 1.9.4
@@ -87,144 +87,84 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
-  '@aws-sdk/client-s3@3.726.0':
-    resolution: {integrity: sha512-cxn2WvOCfGrME2xygWbfj/vIf2sIdv/UbQ9zJbN4aK6rpYQf/e/YtY/HIPkejCuw2Iwqm4jfDGFqaUcwu3nFew==}
-    engines: {node: '>=18.0.0'}
+  '@aws-sdk/checksums@3.1000.6':
+    resolution: {integrity: sha512-RMCrCteiUwYTEv2G9zfP/BEuKHv57665vVieJyp9cf8VgilWxP/KrWVtMdfdDlIH8nFhvu3rIMc29z3ebGEZ1w==}
+    engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/client-sso-oidc@3.726.0':
-    resolution: {integrity: sha512-5JzTX9jwev7+y2Jkzjz0pd1wobB5JQfPOQF3N2DrJ5Pao0/k6uRYwE4NqB0p0HlGrMTDm7xNq7OSPPIPG575Jw==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      '@aws-sdk/client-sts': ^3.726.0
+  '@aws-sdk/client-s3@3.1070.0':
+    resolution: {integrity: sha512-B/OUiCqGQ4Zr7v9gFFyiuitKN2c0PIgvOlQb5bYg1SM2y0F8a5JQ7FNsjRcl+d2PqYWLHwHx12CvZDyLn4KxIw==}
+    engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/client-sso@3.726.0':
-    resolution: {integrity: sha512-NM5pjv2qglEc4XN3nnDqtqGsSGv1k5YTmzDo3W3pObItHmpS8grSeNfX9zSH+aVl0Q8hE4ZIgvTPNZ+GzwVlqg==, tarball: https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.726.0.tgz}
-    engines: {node: '>=18.0.0'}
+  '@aws-sdk/core@3.974.21':
+    resolution: {integrity: sha512-P5JAHvn4dTi96UsAGS67LVOqqpUNNRhnfFXqzCYtdBIGZtqBue4CXvRr9YenOO7PALj/Pn8uuyw53FBCiCYw8w==}
+    engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/client-sts@3.726.0':
-    resolution: {integrity: sha512-047EqXv2BAn/43eP92zsozPnR3paFFMsj5gjytx9kGNtp+WV0fUZNztCOobtouAxBY0ZQ8Xx5RFnmjpRb6Kjsg==}
-    engines: {node: '>=18.0.0'}
+  '@aws-sdk/credential-provider-env@3.972.47':
+    resolution: {integrity: sha512-3YoPwJczcc+MtX2xxXaYaOOWO6xKUJr1ZIIDIFuninr51BYONVVcF/CP8K2xfVRC/PztJjqKWxNGFH7BWQAw1Q==}
+    engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/core@3.723.0':
-    resolution: {integrity: sha512-UraXNmvqj3vScSsTkjMwQkhei30BhXlW5WxX6JacMKVtl95c7z0qOXquTWeTalYkFfulfdirUhvSZrl+hcyqTw==}
-    engines: {node: '>=18.0.0'}
+  '@aws-sdk/credential-provider-http@3.972.49':
+    resolution: {integrity: sha512-2UtGUPy+x3lqyceHrtC1uEuVxBZbDalPF6KAFqBwYgm4edWdBrZKNnCqzDs7KynWUvEC6mrR+ojRk+ZgQz9C2w==}
+    engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-env@3.723.0':
-    resolution: {integrity: sha512-OuH2yULYUHTVDUotBoP/9AEUIJPn81GQ/YBtZLoo2QyezRJ2QiO/1epVtbJlhNZRwXrToLEDmQGA2QfC8c7pbA==}
-    engines: {node: '>=18.0.0'}
+  '@aws-sdk/credential-provider-ini@3.972.54':
+    resolution: {integrity: sha512-Hx4gO4YRjFwitf3MVl3cDwYe1aryJthC4txVl9b+JAURovA50M2ywf9r8j1E/Q6SCTPT4qQpjOAbKYIC9CG+Vw==}
+    engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-http@3.723.0':
-    resolution: {integrity: sha512-DTsKC6xo/kz/ZSs1IcdbQMTgiYbpGTGEd83kngFc1bzmw7AmK92DBZKNZpumf8R/UfSpTcj9zzUUmrWz1kD0eQ==}
-    engines: {node: '>=18.0.0'}
+  '@aws-sdk/credential-provider-login@3.972.53':
+    resolution: {integrity: sha512-+71sluhkgPqdhbbD3UDwUpj24GCkng9HQx6z7qoBFb8dwkF4ktpOcVKDeHpgg8PvBgLYwAnUYLTEGRC/PniCiQ==}
+    engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-ini@3.726.0':
-    resolution: {integrity: sha512-seTtcKL2+gZX6yK1QRPr5mDJIBOatrpoyrO8D5b8plYtV/PDbDW3mtDJSWFHet29G61ZmlNElyXRqQCXn9WX+A==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      '@aws-sdk/client-sts': ^3.726.0
+  '@aws-sdk/credential-provider-node@3.972.56':
+    resolution: {integrity: sha512-iI+4o0dvQQ4NHel4FMDiFy5q2gaU/ryLK3niOsoPccAt9WLFRkV4XTYPWRr9XvmBUqEzXG73S4p/8gm0Lu/W3A==}
+    engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-node@3.726.0':
-    resolution: {integrity: sha512-jjsewBcw/uLi24x8JbnuDjJad4VA9ROCE94uVRbEnGmUEsds75FWOKp3fWZLQlmjLtzsIbJOZLALkZP86liPaw==}
-    engines: {node: '>=18.0.0'}
+  '@aws-sdk/credential-provider-process@3.972.47':
+    resolution: {integrity: sha512-tAizPm9IFo/PHn06c+LQJlzfY2AGOlyF0CUljFejrU6LcZBjnk8pmbZK3/xoIDdnIzjEdbClfvY3mXfr818ZEg==}
+    engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-process@3.723.0':
-    resolution: {integrity: sha512-fgupvUjz1+jeoCBA7GMv0L6xEk92IN6VdF4YcFhsgRHlHvNgm7ayaoKQg7pz2JAAhG/3jPX6fp0ASNy+xOhmPA==}
-    engines: {node: '>=18.0.0'}
+  '@aws-sdk/credential-provider-sso@3.972.53':
+    resolution: {integrity: sha512-pUXE3fu4tfEDV8BksIgf4dXvuIH10FhwHMl/wu8rBD5T1sMpryQWFVitH3kdPS90wlgrGYJQ/meQTSPacyZfeg==}
+    engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-sso@3.726.0':
-    resolution: {integrity: sha512-WxkN76WeB08j2yw7jUH9yCMPxmT9eBFd9ZA/aACG7yzOIlsz7gvG3P2FQ0tVg25GHM0E4PdU3p/ByTOawzcOAg==}
-    engines: {node: '>=18.0.0'}
+  '@aws-sdk/credential-provider-web-identity@3.972.53':
+    resolution: {integrity: sha512-JmMGlhVvSj8uSG9CpeDkJAXT35H89tc6v84iMgEIE75q4yp1MKVVKvopv6Gg28HJIR7hMNkojRF8H2m5W44wyg==}
+    engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-web-identity@3.723.0':
-    resolution: {integrity: sha512-tl7pojbFbr3qLcOE6xWaNCf1zEfZrIdSJtOPeSXfV/thFMMAvIjgf3YN6Zo1a6cxGee8zrV/C8PgOH33n+Ev/A==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      '@aws-sdk/client-sts': ^3.723.0
+  '@aws-sdk/middleware-flexible-checksums@3.974.31':
+    resolution: {integrity: sha512-Yzj6NRYVZdBaCp7o1BwHGyeDBfixdeToLIAMprshIITEdl9wKVSiidVOfeaiH8FyeC1hBmBfDZFvs/aH1Y3xpw==}
+    engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-bucket-endpoint@3.726.0':
-    resolution: {integrity: sha512-vpaP80rZqwu0C3ELayIcRIW84/nd1tadeoqllT+N9TDshuEvq4UJ+w47OBHB7RkHFJoc79lXXNYle0fdQdaE/A==}
-    engines: {node: '>=18.0.0'}
+  '@aws-sdk/middleware-sdk-s3@3.972.52':
+    resolution: {integrity: sha512-rerjP08onRqkBh0AcCqip6GkKvESapmLoTgi1xysZ4C6a1xMrIMtTBcEbUb6EY71oeajnigeUD4KwZjtIO+aWQ==}
+    engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-expect-continue@3.723.0':
-    resolution: {integrity: sha512-w/O0EkIzkiqvGu7U8Ke7tue0V0HYM5dZQrz6nVU+R8T2LddWJ+njEIHU4Wh8aHPLQXdZA5NQumv0xLPdEutykw==}
-    engines: {node: '>=18.0.0'}
+  '@aws-sdk/nested-clients@3.997.21':
+    resolution: {integrity: sha512-eC7Vl7Qom/BGhZjG9GEqPwdQ/fk45hg1t5LP4EUxG5d1fdshLbaxCiwh/tszUzDX/4mW40mu2QsbeJJRPBbqUw==}
+    engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-flexible-checksums@3.723.0':
-    resolution: {integrity: sha512-JY76mrUCLa0FHeMZp8X9+KK6uEuZaRZaQrlgq6zkXX/3udukH0T3YdFC+Y9uw5ddbiwZ5+KwgmlhnPpiXKfP4g==}
-    engines: {node: '>=18.0.0'}
+  '@aws-sdk/signature-v4-multi-region@3.996.35':
+    resolution: {integrity: sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==}
+    engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-host-header@3.723.0':
-    resolution: {integrity: sha512-LLVzLvk299pd7v4jN9yOSaWDZDfH0SnBPb6q+FDPaOCMGBY8kuwQso7e/ozIKSmZHRMGO3IZrflasHM+rI+2YQ==}
-    engines: {node: '>=18.0.0'}
+  '@aws-sdk/token-providers@3.1069.0':
+    resolution: {integrity: sha512-ks4X+kngC3PA5howV7Qu1TgG4bfC4jPykKdvw3nmBSXR9yZxRJouBholFSNQ5kY3L+Fgwyw+LCjzQmNi+KR91g==}
+    engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-location-constraint@3.723.0':
-    resolution: {integrity: sha512-inp9tyrdRWjGOMu1rzli8i2gTo0P4X6L7nNRXNTKfyPNZcBimZ4H0H1B671JofSI5isaklVy5r4pvv2VjjLSHw==}
-    engines: {node: '>=18.0.0'}
-
-  '@aws-sdk/middleware-logger@3.723.0':
-    resolution: {integrity: sha512-chASQfDG5NJ8s5smydOEnNK7N0gDMyuPbx7dYYcm1t/PKtnVfvWF+DHCTrRC2Ej76gLJVCVizlAJKM8v8Kg3cg==}
-    engines: {node: '>=18.0.0'}
-
-  '@aws-sdk/middleware-recursion-detection@3.723.0':
-    resolution: {integrity: sha512-7usZMtoynT9/jxL/rkuDOFQ0C2mhXl4yCm67Rg7GNTstl67u7w5WN1aIRImMeztaKlw8ExjoTyo6WTs1Kceh7A==}
-    engines: {node: '>=18.0.0'}
-
-  '@aws-sdk/middleware-sdk-s3@3.723.0':
-    resolution: {integrity: sha512-wfjOvNJVp8LDWhq4wO5jtSMb8Vgf4tNlR7QTEQfoYc6AGU3WlK5xyUQcpfcpwytEhQTN9u0cJLQpSyXDO+qSCw==}
-    engines: {node: '>=18.0.0'}
-
-  '@aws-sdk/middleware-ssec@3.723.0':
-    resolution: {integrity: sha512-Bs+8RAeSMik6ZYCGSDJzJieGsDDh2fRbh1HQG94T8kpwBXVxMYihm6e9Xp2cyl+w9fyyCnh0IdCKChP/DvrdhA==}
-    engines: {node: '>=18.0.0'}
-
-  '@aws-sdk/middleware-user-agent@3.726.0':
-    resolution: {integrity: sha512-hZvzuE5S0JmFie1r68K2wQvJbzyxJFdzltj9skgnnwdvLe8F/tz7MqLkm28uV0m4jeHk0LpiBo6eZaPkQiwsZQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@aws-sdk/region-config-resolver@3.723.0':
-    resolution: {integrity: sha512-tGF/Cvch3uQjZIj34LY2mg8M2Dr4kYG8VU8Yd0dFnB1ybOEOveIK/9ypUo9ycZpB9oO6q01KRe5ijBaxNueUQg==}
-    engines: {node: '>=18.0.0'}
-
-  '@aws-sdk/signature-v4-multi-region@3.723.0':
-    resolution: {integrity: sha512-lJlVAa5Sl589qO8lwMLVUtnlF1Q7I+6k1Iomv2goY9d1bRl4q2N5Pit2qJVr2AMW0sceQXeh23i2a/CKOqVAdg==}
-    engines: {node: '>=18.0.0'}
-
-  '@aws-sdk/token-providers@3.723.0':
-    resolution: {integrity: sha512-hniWi1x4JHVwKElANh9afKIMUhAutHVBRD8zo6usr0PAoj+Waf220+1ULS74GXtLXAPCiNXl5Og+PHA7xT8ElQ==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      '@aws-sdk/client-sso-oidc': ^3.723.0
-
-  '@aws-sdk/types@3.723.0':
-    resolution: {integrity: sha512-LmK3kwiMZG1y5g3LGihT9mNkeNOmwEyPk6HGcJqh0wOSV4QpWoKu2epyKE4MLQNUUlz2kOVbVbOrwmI6ZcteuA==}
-    engines: {node: '>=18.0.0'}
-
-  '@aws-sdk/util-arn-parser@3.723.0':
-    resolution: {integrity: sha512-ZhEfvUwNliOQROcAk34WJWVYTlTa4694kSVhDSjW6lE1bMataPnIN8A0ycukEzBXmd8ZSoBcQLn6lKGl7XIJ5w==}
-    engines: {node: '>=18.0.0'}
-
-  '@aws-sdk/util-endpoints@3.726.0':
-    resolution: {integrity: sha512-sLd30ASsPMoPn3XBK50oe/bkpJ4N8Bpb7SbhoxcY3Lk+fSASaWxbbXE81nbvCnkxrZCvkPOiDHzJCp1E2im71A==}
-    engines: {node: '>=18.0.0'}
+  '@aws-sdk/types@3.973.13':
+    resolution: {integrity: sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==}
+    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-locate-window@3.965.8':
     resolution: {integrity: sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-user-agent-browser@3.723.0':
-    resolution: {integrity: sha512-Wh9I6j2jLhNFq6fmXydIpqD1WyQLyTfSxjW9B+PXSnPyk3jtQW8AKQur7p97rO8LAUzVI0bv8kb3ZzDEVbquIg==}
+  '@aws-sdk/xml-builder@3.972.30':
+    resolution: {integrity: sha512-StElZPEoBquWwNqw1AcfpzEyZqJvFxouG+mpDNYlcH6ZOrqd2CuIryv+8LV8gNHZUOyKyJF3Dq9vxaXEmDR9TQ==}
+    engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-user-agent-node@3.726.0':
-    resolution: {integrity: sha512-iEj6KX9o6IQf23oziorveRqyzyclWai95oZHDJtYav3fvLJKStwSjygO4xSF7ycHcTYeCHSLO1FFOHgGVs4Viw==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      aws-crt: '>=1.0.0'
-    peerDependenciesMeta:
-      aws-crt:
-        optional: true
-
-  '@aws-sdk/xml-builder@3.723.0':
-    resolution: {integrity: sha512-5xK2SqGU1mzzsOeemy7cy3fGKxR1sEpUs4pEiIjaT0OIvU+fZaDVUEYWOqsgns6wI90XZEQJlXtI8uAHX/do5Q==}
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
     engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.7':
@@ -754,6 +694,9 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
+  '@nodable/entities@2.2.0':
+    resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
+
   '@octokit/auth-token@6.0.0':
     resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
     engines: {node: '>= 20'}
@@ -1065,10 +1008,6 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
-  '@smithy/config-resolver@4.6.0':
-    resolution: {integrity: sha512-NJF/Xc69G68BzZMKMEpWkCY9HjZJzTWztTW4VxBC2SodX+H60xw+NGckNhkgg4uMRHrpDkhWeBeigM3YJmv1FQ==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/core@3.25.0':
     resolution: {integrity: sha512-TTD6el7tvKyafkXBf7XO3jLOE+qVxOTrLjp/fEGiV3BMfUHK/LfdYlQO9YgZvzxC7kqA3H/IhJXNqQgnbgjb7A==}
     engines: {node: '>=18.0.0'}
@@ -1077,161 +1016,33 @@ packages:
     resolution: {integrity: sha512-pPQmNdEvMJttv9z2kdYxoui83p/nr32zjMf0aMfmzmGmFEgKXUfy0vXiNg0fx4R5XLQzmJBLM9Wg0guEq2/q8A==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/eventstream-serde-browser@4.4.0':
-    resolution: {integrity: sha512-VIViKuJIgQ5eb66Su0LshXQNf3oJ0QXQ3gDg/rXJ47mFN6wmoolUT7OwczRdjpHGIH4T99aPSLURb9YYoLZqmQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/eventstream-serde-config-resolver@4.5.0':
-    resolution: {integrity: sha512-JtUvQ4EP4+KtNkwSLFRIzHdFftfZ+CQ8g95xT6uBzCFCu23Lt4sr6neQXmNHLM9RJ9Vw20LdcTBXtw3h4J1qeA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/eventstream-serde-node@4.4.0':
-    resolution: {integrity: sha512-N8TeITQmnPZNKgjVaoHm4pOUPAeIPWAqTZVhEltxEbWsYciC6NezCw/TjUudgoiU8ljpvpzxQiZ3TLWMvadNMg==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/fetch-http-handler@5.5.0':
     resolution: {integrity: sha512-OG8kBYAgX7lf32+xLzgirvuLffn1KNoszaSiButt45i2cRa5irk8LQXLYQ5Smij1SBTN4KMNcBsRwRrLPfIGyA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/hash-blob-browser@4.4.0':
-    resolution: {integrity: sha512-3R52ZjnJhey3zlp9K1ixVGQIO9NOaHF/MJR5wLbFsEOn4EG8M41Cp6a7duMLEw7FYEO+ikO/5Q0vghErT3uaKg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/hash-node@4.4.0':
-    resolution: {integrity: sha512-MkyiJfdnDlBdmq26Cxskw2dtX6V/EgTjCriPc7Gq0084hncjIFVJ26IwHpauXJT2w79B4umF0erKi4epBR/WDA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/hash-stream-node@4.4.0':
-    resolution: {integrity: sha512-wdhUbsxG+xpUhtpPr6Qb5si1JizQjLJwZKP5uQQrHLIxEBJ27wrnWt6FEKs/6BBUA0aqfTbiZ/aUr6IqRfl8SA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/invalid-dependency@4.4.0':
-    resolution: {integrity: sha512-KWyzbLxpEcr4iU8A/Bu4zZN9w9LdXT6SO2jfbwP21xdNr2JyW8XBowOKViG/dHp912ekAmtJ7SDfPapj7yS7JQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/is-array-buffer@2.2.0':
     resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
     engines: {node: '>=14.0.0'}
 
-  '@smithy/is-array-buffer@4.4.0':
-    resolution: {integrity: sha512-EZ6yOBlyezpi9BaP1rBFL3+2R4oDq0aUlgmrlFRuckVH7UdP4/fnFma1ozc8Td33y7eVY/yHpQVh7phvddZ6Lw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/md5-js@4.4.0':
-    resolution: {integrity: sha512-/TkyVulxTrirvSUs8hvyYH1V/sKxaO2RTmAW7oh6D6wyNPh8TPUxpk1RYSY5wd8bMZpKfh8FSEMIkLSTnN/Pjw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-content-length@4.4.0':
-    resolution: {integrity: sha512-hLdaOvB2JIZhOa6REhHJHXQavMQC5EvewIiWM/mk9AWGlwoo6QyAXlYsp621AexTqY44558s3e3vzLHwyPhlsA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-endpoint@4.6.0':
-    resolution: {integrity: sha512-yPaTGexBoXq70QMw/dIq/E4pLQMgBtSmAV23XyZm9UcMoGMS7efa2HMy+LvhlnDgyqCeXn8mQ7k+e4uD6rbjew==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-retry@4.7.0':
-    resolution: {integrity: sha512-Br+n69+Hc6HwZZmRfhrEB7q7C6MZBghxlCugZHnvnPJN/bsMYG3d4hzhXjJr4EyBkxhe5hcvtZpgUDJhdmV22g==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-serde@4.4.0':
-    resolution: {integrity: sha512-bDnLiVuVciCC4d2n/PCcGJrKwgQupNIeuMNZvkStsGGeeVJ9WDjTpDwEYZTiXSIFszvzt7FVX3l5rsB3puNDbA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-stack@4.4.0':
-    resolution: {integrity: sha512-tZUD0fE+/aLzLS4b75SDyQXBybPCI9UqwEAhDRmME8ObjEtnMnA6Hrt0FCNMN+JPoCtcrbUS0cHPXFTQMDtgoA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/node-config-provider@4.5.0':
-    resolution: {integrity: sha512-hwea2f5OKcsZMKGgMYzWyclQKoMMbXzFVuv4033sc23dEjGOscqQ0hGHLDQcSneSsIZ8WcwxCV9y+ou34xoizA==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/node-http-handler@4.8.0':
     resolution: {integrity: sha512-Mq7TNt/VhlEWiYRLQGpzUWeUxh899UGpjKh7Ru0WVIDIjnE+cTRAn0NYlFQ6bWfsQnKnpCbWJj86HzmcG0qEdg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/property-provider@4.4.0':
-    resolution: {integrity: sha512-btjt5ZSO1JOrFJM8Wzzuqlzu3pc+iGb3InhyRbHX/LzK4gn4/SnfjCEdNAf912tcgcjfi5b2kiaNGz9vlT1Eog==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/protocol-http@5.5.0':
-    resolution: {integrity: sha512-gqvRWWZIcqmj7iS68p+hrxiOg1fGQcfzNPUlSGJ69hzLHyCyIRApasCpAp/xMGRgb6QqVH/YQhztOYgs+ZI3kA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/shared-ini-file-loader@4.6.0':
-    resolution: {integrity: sha512-O/cWx1tDsuyi5I1EkfsrJMnVNfcSvpKmAqp/dKtVfFSIm9Wa/IgVYV7x98OAK7T38eLfRU5/xpVgolC84Ul2UQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/signature-v4@5.5.0':
     resolution: {integrity: sha512-vW6UdK7e7gV2wU/tXRsPq4pMQMusb8VymdVOyIFNA1FtyRmEClRFkYDtYI8UcO/HM0wK3qqjvvQs3HOlbgMbdg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/smithy-client@4.14.0':
-    resolution: {integrity: sha512-pBJs2oWyl/drgw1lQOdwjXEwEeL36PN/CeRt33lwBu1OZTmoKqQjp93vcjM9fjv5ETsgEzB7WLSX6rYKKP0Eqw==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/types@4.15.0':
     resolution: {integrity: sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/url-parser@4.4.0':
-    resolution: {integrity: sha512-E73GGqNThq6SLLOgQKU5re/iDc1oPk21zPr0t4KUD/sj6qlB06vQX/5xu3H8lTnCqWh9oLr1tXsv2Cpu74TTLg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-base64@4.5.0':
-    resolution: {integrity: sha512-SF3V9ZZ9KotchuyxHdOvi1Y8OO7ZS+mDzoasCIrni9HEDf/BsBqCA9BAKHG+waerz4nutHPGDMRQw8B6VtVCsg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-body-length-browser@4.4.0':
-    resolution: {integrity: sha512-JU3CDQScfAA9inuNyIQVNbHJ54fhtwXQqwBkR0xQN9lyGkFgFKnzHFgNQonfu67O5kdcnv1bOxhqsfrwmg2i1A==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-body-length-node@4.4.0':
-    resolution: {integrity: sha512-Hu7UCgEGGxjT8pUsaYq4K7tfhShBXYnRU68GRia3H7dzjtU4AX9/jdVS4qhNn4lSdxA+d76iRESNu0jduT1Pjg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-buffer-from@2.2.0':
     resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
     engines: {node: '>=14.0.0'}
 
-  '@smithy/util-config-provider@4.4.0':
-    resolution: {integrity: sha512-8CFmtq72pxt9r1a4opNuTgI+P6WfiN1ZCI2bREmKtxYmYakSwAWBn4UieEf/q5YOdM2+jJ+A7GqBtsXbkI7bwQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-defaults-mode-browser@4.5.0':
-    resolution: {integrity: sha512-T4/V3fCSnhNg5xLlxxo5H8YsBblVtCnvrSb+XLhUjngUzu8W53uAxdUOKXQTN3HWVBlBOa5sD+BJb6FOqNtkYg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-defaults-mode-node@4.4.0':
-    resolution: {integrity: sha512-4ZjhBmU8Dt1OFBY8GfKHalfPy0BF4/IrSGMuhiPRc81bbRbLP/rPH65LrLgokm3rd/wzRpTwSEKNeKSAnYHSdg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-endpoints@3.6.0':
-    resolution: {integrity: sha512-g8tR/yXtx08j1NMdaFsMy0caBFeTl6l4fbQWvyjKQJ5rUMf5oqV69iyrqwfl7tuD9N9cJo23yqpzrGmbYp8r3g==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-middleware@4.4.0':
-    resolution: {integrity: sha512-XMhUiohsBJVwzJeS+w8y6E43I4rz/5ZpreSQAa6/gtNiXVBFhSw0inCKod5sJxuEETY2tTtK132lKcHVZAFgEQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-retry@4.5.0':
-    resolution: {integrity: sha512-l8i4lcA4AzvOc+aiMz8UyU7lSEgOmXd1Xktrhp7h1sO55j1VygpVUr/dAIfX9liY5HbDvDhTFZCgVHsYGlAoWw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-stream@4.7.0':
-    resolution: {integrity: sha512-lZfQFdsC48pRqCSv8R1jrjaAOJadldqH6ZbnaWgv9mKy77yYrMsqFam131hoa1obeydN2Qz52uUu+k9Og4W9sQ==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/util-utf8@2.3.0':
     resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
     engines: {node: '>=14.0.0'}
-
-  '@smithy/util-utf8@4.4.0':
-    resolution: {integrity: sha512-dMvQY14daYwEfKR+/ACROrUwJ5onUue7d9o4KJo4gaecn5eVzxlCbSeU9GSh0ojFpIiI1bpnJJxO1wY2VXDEtQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-waiter@4.5.0':
-    resolution: {integrity: sha512-BbTtz3ULP1na8PvteT1buTof7rUxcQd127FEjCT6jO99G2H3BR/OAlBRjWPZKJ9QvJPdYupR9/ai+rrnA8xneg==}
-    engines: {node: '>=18.0.0'}
 
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
@@ -1398,6 +1209,9 @@ packages:
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  anynum@1.0.0:
+    resolution: {integrity: sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==}
 
   archiver-utils@5.0.2:
     resolution: {integrity: sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==}
@@ -1902,8 +1716,11 @@ packages:
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
-  fast-xml-parser@4.4.1:
-    resolution: {integrity: sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==}
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.7.3:
+    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
     hasBin: true
 
   fdir@6.5.0:
@@ -2581,6 +2398,10 @@ packages:
     resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
     engines: {node: '>=4'}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -2898,8 +2719,8 @@ packages:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
 
-  strnum@1.1.2:
-    resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
+  strnum@2.4.0:
+    resolution: {integrity: sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==}
 
   super-regex@1.1.0:
     resolution: {integrity: sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==}
@@ -3238,6 +3059,10 @@ packages:
     resolution: {integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==}
     engines: {node: '>=12'}
 
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -3313,20 +3138,20 @@ snapshots:
   '@aws-crypto/crc32@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.723.0
+      '@aws-sdk/types': 3.973.13
       tslib: 2.8.1
 
   '@aws-crypto/crc32c@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.723.0
+      '@aws-sdk/types': 3.973.13
       tslib: 2.8.1
 
   '@aws-crypto/sha1-browser@5.2.0':
     dependencies:
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.723.0
+      '@aws-sdk/types': 3.973.13
       '@aws-sdk/util-locate-window': 3.965.8
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -3336,7 +3161,7 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.723.0
+      '@aws-sdk/types': 3.973.13
       '@aws-sdk/util-locate-window': 3.965.8
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -3344,7 +3169,7 @@ snapshots:
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.723.0
+      '@aws-sdk/types': 3.973.13
       tslib: 2.8.1
 
   '@aws-crypto/supports-web-crypto@5.2.0':
@@ -3353,469 +3178,192 @@ snapshots:
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.723.0
+      '@aws-sdk/types': 3.973.13
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
-  '@aws-sdk/client-s3@3.726.0':
-    dependencies:
-      '@aws-crypto/sha1-browser': 5.2.0
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sso-oidc': 3.726.0(@aws-sdk/client-sts@3.726.0)
-      '@aws-sdk/client-sts': 3.726.0
-      '@aws-sdk/core': 3.723.0
-      '@aws-sdk/credential-provider-node': 3.726.0(@aws-sdk/client-sso-oidc@3.726.0(@aws-sdk/client-sts@3.726.0))(@aws-sdk/client-sts@3.726.0)
-      '@aws-sdk/middleware-bucket-endpoint': 3.726.0
-      '@aws-sdk/middleware-expect-continue': 3.723.0
-      '@aws-sdk/middleware-flexible-checksums': 3.723.0
-      '@aws-sdk/middleware-host-header': 3.723.0
-      '@aws-sdk/middleware-location-constraint': 3.723.0
-      '@aws-sdk/middleware-logger': 3.723.0
-      '@aws-sdk/middleware-recursion-detection': 3.723.0
-      '@aws-sdk/middleware-sdk-s3': 3.723.0
-      '@aws-sdk/middleware-ssec': 3.723.0
-      '@aws-sdk/middleware-user-agent': 3.726.0
-      '@aws-sdk/region-config-resolver': 3.723.0
-      '@aws-sdk/signature-v4-multi-region': 3.723.0
-      '@aws-sdk/types': 3.723.0
-      '@aws-sdk/util-endpoints': 3.726.0
-      '@aws-sdk/util-user-agent-browser': 3.723.0
-      '@aws-sdk/util-user-agent-node': 3.726.0
-      '@aws-sdk/xml-builder': 3.723.0
-      '@smithy/config-resolver': 4.6.0
-      '@smithy/core': 3.25.0
-      '@smithy/eventstream-serde-browser': 4.4.0
-      '@smithy/eventstream-serde-config-resolver': 4.5.0
-      '@smithy/eventstream-serde-node': 4.4.0
-      '@smithy/fetch-http-handler': 5.5.0
-      '@smithy/hash-blob-browser': 4.4.0
-      '@smithy/hash-node': 4.4.0
-      '@smithy/hash-stream-node': 4.4.0
-      '@smithy/invalid-dependency': 4.4.0
-      '@smithy/md5-js': 4.4.0
-      '@smithy/middleware-content-length': 4.4.0
-      '@smithy/middleware-endpoint': 4.6.0
-      '@smithy/middleware-retry': 4.7.0
-      '@smithy/middleware-serde': 4.4.0
-      '@smithy/middleware-stack': 4.4.0
-      '@smithy/node-config-provider': 4.5.0
-      '@smithy/node-http-handler': 4.8.0
-      '@smithy/protocol-http': 5.5.0
-      '@smithy/smithy-client': 4.14.0
-      '@smithy/types': 4.15.0
-      '@smithy/url-parser': 4.4.0
-      '@smithy/util-base64': 4.5.0
-      '@smithy/util-body-length-browser': 4.4.0
-      '@smithy/util-body-length-node': 4.4.0
-      '@smithy/util-defaults-mode-browser': 4.5.0
-      '@smithy/util-defaults-mode-node': 4.4.0
-      '@smithy/util-endpoints': 3.6.0
-      '@smithy/util-middleware': 4.4.0
-      '@smithy/util-retry': 4.5.0
-      '@smithy/util-stream': 4.7.0
-      '@smithy/util-utf8': 4.4.0
-      '@smithy/util-waiter': 4.5.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/client-sso-oidc@3.726.0(@aws-sdk/client-sts@3.726.0)':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sts': 3.726.0
-      '@aws-sdk/core': 3.723.0
-      '@aws-sdk/credential-provider-node': 3.726.0(@aws-sdk/client-sso-oidc@3.726.0(@aws-sdk/client-sts@3.726.0))(@aws-sdk/client-sts@3.726.0)
-      '@aws-sdk/middleware-host-header': 3.723.0
-      '@aws-sdk/middleware-logger': 3.723.0
-      '@aws-sdk/middleware-recursion-detection': 3.723.0
-      '@aws-sdk/middleware-user-agent': 3.726.0
-      '@aws-sdk/region-config-resolver': 3.723.0
-      '@aws-sdk/types': 3.723.0
-      '@aws-sdk/util-endpoints': 3.726.0
-      '@aws-sdk/util-user-agent-browser': 3.723.0
-      '@aws-sdk/util-user-agent-node': 3.726.0
-      '@smithy/config-resolver': 4.6.0
-      '@smithy/core': 3.25.0
-      '@smithy/fetch-http-handler': 5.5.0
-      '@smithy/hash-node': 4.4.0
-      '@smithy/invalid-dependency': 4.4.0
-      '@smithy/middleware-content-length': 4.4.0
-      '@smithy/middleware-endpoint': 4.6.0
-      '@smithy/middleware-retry': 4.7.0
-      '@smithy/middleware-serde': 4.4.0
-      '@smithy/middleware-stack': 4.4.0
-      '@smithy/node-config-provider': 4.5.0
-      '@smithy/node-http-handler': 4.8.0
-      '@smithy/protocol-http': 5.5.0
-      '@smithy/smithy-client': 4.14.0
-      '@smithy/types': 4.15.0
-      '@smithy/url-parser': 4.4.0
-      '@smithy/util-base64': 4.5.0
-      '@smithy/util-body-length-browser': 4.4.0
-      '@smithy/util-body-length-node': 4.4.0
-      '@smithy/util-defaults-mode-browser': 4.5.0
-      '@smithy/util-defaults-mode-node': 4.4.0
-      '@smithy/util-endpoints': 3.6.0
-      '@smithy/util-middleware': 4.4.0
-      '@smithy/util-retry': 4.5.0
-      '@smithy/util-utf8': 4.4.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/client-sso@3.726.0':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.723.0
-      '@aws-sdk/middleware-host-header': 3.723.0
-      '@aws-sdk/middleware-logger': 3.723.0
-      '@aws-sdk/middleware-recursion-detection': 3.723.0
-      '@aws-sdk/middleware-user-agent': 3.726.0
-      '@aws-sdk/region-config-resolver': 3.723.0
-      '@aws-sdk/types': 3.723.0
-      '@aws-sdk/util-endpoints': 3.726.0
-      '@aws-sdk/util-user-agent-browser': 3.723.0
-      '@aws-sdk/util-user-agent-node': 3.726.0
-      '@smithy/config-resolver': 4.6.0
-      '@smithy/core': 3.25.0
-      '@smithy/fetch-http-handler': 5.5.0
-      '@smithy/hash-node': 4.4.0
-      '@smithy/invalid-dependency': 4.4.0
-      '@smithy/middleware-content-length': 4.4.0
-      '@smithy/middleware-endpoint': 4.6.0
-      '@smithy/middleware-retry': 4.7.0
-      '@smithy/middleware-serde': 4.4.0
-      '@smithy/middleware-stack': 4.4.0
-      '@smithy/node-config-provider': 4.5.0
-      '@smithy/node-http-handler': 4.8.0
-      '@smithy/protocol-http': 5.5.0
-      '@smithy/smithy-client': 4.14.0
-      '@smithy/types': 4.15.0
-      '@smithy/url-parser': 4.4.0
-      '@smithy/util-base64': 4.5.0
-      '@smithy/util-body-length-browser': 4.4.0
-      '@smithy/util-body-length-node': 4.4.0
-      '@smithy/util-defaults-mode-browser': 4.5.0
-      '@smithy/util-defaults-mode-node': 4.4.0
-      '@smithy/util-endpoints': 3.6.0
-      '@smithy/util-middleware': 4.4.0
-      '@smithy/util-retry': 4.5.0
-      '@smithy/util-utf8': 4.4.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/client-sts@3.726.0':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sso-oidc': 3.726.0(@aws-sdk/client-sts@3.726.0)
-      '@aws-sdk/core': 3.723.0
-      '@aws-sdk/credential-provider-node': 3.726.0(@aws-sdk/client-sso-oidc@3.726.0(@aws-sdk/client-sts@3.726.0))(@aws-sdk/client-sts@3.726.0)
-      '@aws-sdk/middleware-host-header': 3.723.0
-      '@aws-sdk/middleware-logger': 3.723.0
-      '@aws-sdk/middleware-recursion-detection': 3.723.0
-      '@aws-sdk/middleware-user-agent': 3.726.0
-      '@aws-sdk/region-config-resolver': 3.723.0
-      '@aws-sdk/types': 3.723.0
-      '@aws-sdk/util-endpoints': 3.726.0
-      '@aws-sdk/util-user-agent-browser': 3.723.0
-      '@aws-sdk/util-user-agent-node': 3.726.0
-      '@smithy/config-resolver': 4.6.0
-      '@smithy/core': 3.25.0
-      '@smithy/fetch-http-handler': 5.5.0
-      '@smithy/hash-node': 4.4.0
-      '@smithy/invalid-dependency': 4.4.0
-      '@smithy/middleware-content-length': 4.4.0
-      '@smithy/middleware-endpoint': 4.6.0
-      '@smithy/middleware-retry': 4.7.0
-      '@smithy/middleware-serde': 4.4.0
-      '@smithy/middleware-stack': 4.4.0
-      '@smithy/node-config-provider': 4.5.0
-      '@smithy/node-http-handler': 4.8.0
-      '@smithy/protocol-http': 5.5.0
-      '@smithy/smithy-client': 4.14.0
-      '@smithy/types': 4.15.0
-      '@smithy/url-parser': 4.4.0
-      '@smithy/util-base64': 4.5.0
-      '@smithy/util-body-length-browser': 4.4.0
-      '@smithy/util-body-length-node': 4.4.0
-      '@smithy/util-defaults-mode-browser': 4.5.0
-      '@smithy/util-defaults-mode-node': 4.4.0
-      '@smithy/util-endpoints': 3.6.0
-      '@smithy/util-middleware': 4.4.0
-      '@smithy/util-retry': 4.5.0
-      '@smithy/util-utf8': 4.4.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/core@3.723.0':
-    dependencies:
-      '@aws-sdk/types': 3.723.0
-      '@smithy/core': 3.25.0
-      '@smithy/node-config-provider': 4.5.0
-      '@smithy/property-provider': 4.4.0
-      '@smithy/protocol-http': 5.5.0
-      '@smithy/signature-v4': 5.5.0
-      '@smithy/smithy-client': 4.14.0
-      '@smithy/types': 4.15.0
-      '@smithy/util-middleware': 4.4.0
-      fast-xml-parser: 4.4.1
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-env@3.723.0':
-    dependencies:
-      '@aws-sdk/core': 3.723.0
-      '@aws-sdk/types': 3.723.0
-      '@smithy/property-provider': 4.4.0
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-http@3.723.0':
-    dependencies:
-      '@aws-sdk/core': 3.723.0
-      '@aws-sdk/types': 3.723.0
-      '@smithy/fetch-http-handler': 5.5.0
-      '@smithy/node-http-handler': 4.8.0
-      '@smithy/property-provider': 4.4.0
-      '@smithy/protocol-http': 5.5.0
-      '@smithy/smithy-client': 4.14.0
-      '@smithy/types': 4.15.0
-      '@smithy/util-stream': 4.7.0
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-ini@3.726.0(@aws-sdk/client-sso-oidc@3.726.0(@aws-sdk/client-sts@3.726.0))(@aws-sdk/client-sts@3.726.0)':
-    dependencies:
-      '@aws-sdk/client-sts': 3.726.0
-      '@aws-sdk/core': 3.723.0
-      '@aws-sdk/credential-provider-env': 3.723.0
-      '@aws-sdk/credential-provider-http': 3.723.0
-      '@aws-sdk/credential-provider-process': 3.723.0
-      '@aws-sdk/credential-provider-sso': 3.726.0(@aws-sdk/client-sso-oidc@3.726.0(@aws-sdk/client-sts@3.726.0))
-      '@aws-sdk/credential-provider-web-identity': 3.723.0(@aws-sdk/client-sts@3.726.0)
-      '@aws-sdk/types': 3.723.0
-      '@smithy/credential-provider-imds': 4.4.0
-      '@smithy/property-provider': 4.4.0
-      '@smithy/shared-ini-file-loader': 4.6.0
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
-      - aws-crt
-
-  '@aws-sdk/credential-provider-node@3.726.0(@aws-sdk/client-sso-oidc@3.726.0(@aws-sdk/client-sts@3.726.0))(@aws-sdk/client-sts@3.726.0)':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.723.0
-      '@aws-sdk/credential-provider-http': 3.723.0
-      '@aws-sdk/credential-provider-ini': 3.726.0(@aws-sdk/client-sso-oidc@3.726.0(@aws-sdk/client-sts@3.726.0))(@aws-sdk/client-sts@3.726.0)
-      '@aws-sdk/credential-provider-process': 3.723.0
-      '@aws-sdk/credential-provider-sso': 3.726.0(@aws-sdk/client-sso-oidc@3.726.0(@aws-sdk/client-sts@3.726.0))
-      '@aws-sdk/credential-provider-web-identity': 3.723.0(@aws-sdk/client-sts@3.726.0)
-      '@aws-sdk/types': 3.723.0
-      '@smithy/credential-provider-imds': 4.4.0
-      '@smithy/property-provider': 4.4.0
-      '@smithy/shared-ini-file-loader': 4.6.0
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
-      - '@aws-sdk/client-sts'
-      - aws-crt
-
-  '@aws-sdk/credential-provider-process@3.723.0':
-    dependencies:
-      '@aws-sdk/core': 3.723.0
-      '@aws-sdk/types': 3.723.0
-      '@smithy/property-provider': 4.4.0
-      '@smithy/shared-ini-file-loader': 4.6.0
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-sso@3.726.0(@aws-sdk/client-sso-oidc@3.726.0(@aws-sdk/client-sts@3.726.0))':
-    dependencies:
-      '@aws-sdk/client-sso': 3.726.0
-      '@aws-sdk/core': 3.723.0
-      '@aws-sdk/token-providers': 3.723.0(@aws-sdk/client-sso-oidc@3.726.0(@aws-sdk/client-sts@3.726.0))
-      '@aws-sdk/types': 3.723.0
-      '@smithy/property-provider': 4.4.0
-      '@smithy/shared-ini-file-loader': 4.6.0
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
-      - aws-crt
-
-  '@aws-sdk/credential-provider-web-identity@3.723.0(@aws-sdk/client-sts@3.726.0)':
-    dependencies:
-      '@aws-sdk/client-sts': 3.726.0
-      '@aws-sdk/core': 3.723.0
-      '@aws-sdk/types': 3.723.0
-      '@smithy/property-provider': 4.4.0
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-bucket-endpoint@3.726.0':
-    dependencies:
-      '@aws-sdk/types': 3.723.0
-      '@aws-sdk/util-arn-parser': 3.723.0
-      '@smithy/node-config-provider': 4.5.0
-      '@smithy/protocol-http': 5.5.0
-      '@smithy/types': 4.15.0
-      '@smithy/util-config-provider': 4.4.0
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-expect-continue@3.723.0':
-    dependencies:
-      '@aws-sdk/types': 3.723.0
-      '@smithy/protocol-http': 5.5.0
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-flexible-checksums@3.723.0':
+  '@aws-sdk/checksums@3.1000.6':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
       '@aws-crypto/crc32c': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/core': 3.723.0
-      '@aws-sdk/types': 3.723.0
-      '@smithy/is-array-buffer': 4.4.0
-      '@smithy/node-config-provider': 4.5.0
-      '@smithy/protocol-http': 5.5.0
-      '@smithy/types': 4.15.0
-      '@smithy/util-middleware': 4.4.0
-      '@smithy/util-stream': 4.7.0
-      '@smithy/util-utf8': 4.4.0
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-host-header@3.723.0':
-    dependencies:
-      '@aws-sdk/types': 3.723.0
-      '@smithy/protocol-http': 5.5.0
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-location-constraint@3.723.0':
-    dependencies:
-      '@aws-sdk/types': 3.723.0
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-logger@3.723.0':
-    dependencies:
-      '@aws-sdk/types': 3.723.0
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-recursion-detection@3.723.0':
-    dependencies:
-      '@aws-sdk/types': 3.723.0
-      '@smithy/protocol-http': 5.5.0
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-sdk-s3@3.723.0':
-    dependencies:
-      '@aws-sdk/core': 3.723.0
-      '@aws-sdk/types': 3.723.0
-      '@aws-sdk/util-arn-parser': 3.723.0
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.25.0
-      '@smithy/node-config-provider': 4.5.0
-      '@smithy/protocol-http': 5.5.0
-      '@smithy/signature-v4': 5.5.0
-      '@smithy/smithy-client': 4.14.0
-      '@smithy/types': 4.15.0
-      '@smithy/util-config-provider': 4.4.0
-      '@smithy/util-middleware': 4.4.0
-      '@smithy/util-stream': 4.7.0
-      '@smithy/util-utf8': 4.4.0
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-ssec@3.723.0':
-    dependencies:
-      '@aws-sdk/types': 3.723.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-user-agent@3.726.0':
+  '@aws-sdk/client-s3@3.1070.0':
     dependencies:
-      '@aws-sdk/core': 3.723.0
-      '@aws-sdk/types': 3.723.0
-      '@aws-sdk/util-endpoints': 3.726.0
+      '@aws-crypto/sha1-browser': 5.2.0
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/credential-provider-node': 3.972.56
+      '@aws-sdk/middleware-flexible-checksums': 3.974.31
+      '@aws-sdk/middleware-sdk-s3': 3.972.52
+      '@aws-sdk/signature-v4-multi-region': 3.996.35
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.25.0
-      '@smithy/protocol-http': 5.5.0
+      '@smithy/fetch-http-handler': 5.5.0
+      '@smithy/node-http-handler': 4.8.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
-  '@aws-sdk/region-config-resolver@3.723.0':
+  '@aws-sdk/core@3.974.21':
     dependencies:
-      '@aws-sdk/types': 3.723.0
-      '@smithy/node-config-provider': 4.5.0
-      '@smithy/types': 4.15.0
-      '@smithy/util-config-provider': 4.4.0
-      '@smithy/util-middleware': 4.4.0
-      tslib: 2.8.1
-
-  '@aws-sdk/signature-v4-multi-region@3.723.0':
-    dependencies:
-      '@aws-sdk/middleware-sdk-s3': 3.723.0
-      '@aws-sdk/types': 3.723.0
-      '@smithy/protocol-http': 5.5.0
+      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/xml-builder': 3.972.30
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.25.0
       '@smithy/signature-v4': 5.5.0
       '@smithy/types': 4.15.0
+      bowser: 2.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/token-providers@3.723.0(@aws-sdk/client-sso-oidc@3.726.0(@aws-sdk/client-sts@3.726.0))':
+  '@aws-sdk/credential-provider-env@3.972.47':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.726.0(@aws-sdk/client-sts@3.726.0)
-      '@aws-sdk/types': 3.723.0
-      '@smithy/property-provider': 4.4.0
-      '@smithy/shared-ini-file-loader': 4.6.0
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
-  '@aws-sdk/types@3.723.0':
+  '@aws-sdk/credential-provider-http@3.972.49':
     dependencies:
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.0
+      '@smithy/fetch-http-handler': 5.5.0
+      '@smithy/node-http-handler': 4.8.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
-  '@aws-sdk/util-arn-parser@3.723.0':
+  '@aws-sdk/credential-provider-ini@3.972.54':
     dependencies:
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/credential-provider-env': 3.972.47
+      '@aws-sdk/credential-provider-http': 3.972.49
+      '@aws-sdk/credential-provider-login': 3.972.53
+      '@aws-sdk/credential-provider-process': 3.972.47
+      '@aws-sdk/credential-provider-sso': 3.972.53
+      '@aws-sdk/credential-provider-web-identity': 3.972.53
+      '@aws-sdk/nested-clients': 3.997.21
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.0
+      '@smithy/credential-provider-imds': 4.4.0
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
-  '@aws-sdk/util-endpoints@3.726.0':
+  '@aws-sdk/credential-provider-login@3.972.53':
     dependencies:
-      '@aws-sdk/types': 3.723.0
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/nested-clients': 3.997.21
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.0
       '@smithy/types': 4.15.0
-      '@smithy/util-endpoints': 3.6.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.56':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.47
+      '@aws-sdk/credential-provider-http': 3.972.49
+      '@aws-sdk/credential-provider-ini': 3.972.54
+      '@aws-sdk/credential-provider-process': 3.972.47
+      '@aws-sdk/credential-provider-sso': 3.972.53
+      '@aws-sdk/credential-provider-web-identity': 3.972.53
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.0
+      '@smithy/credential-provider-imds': 4.4.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.47':
+    dependencies:
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.53':
+    dependencies:
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/nested-clients': 3.997.21
+      '@aws-sdk/token-providers': 3.1069.0
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.53':
+    dependencies:
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/nested-clients': 3.997.21
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.31':
+    dependencies:
+      '@aws-sdk/checksums': 3.1000.6
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.52':
+    dependencies:
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/signature-v4-multi-region': 3.996.35
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.21':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/signature-v4-multi-region': 3.996.35
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.0
+      '@smithy/fetch-http-handler': 5.5.0
+      '@smithy/node-http-handler': 4.8.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.35':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@smithy/signature-v4': 5.5.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1069.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/nested-clients': 3.997.21
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.13':
+    dependencies:
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/util-locate-window@3.965.8':
     dependencies:
       tslib: 2.8.1
 
-  '@aws-sdk/util-user-agent-browser@3.723.0':
+  '@aws-sdk/xml-builder@3.972.30':
     dependencies:
-      '@aws-sdk/types': 3.723.0
       '@smithy/types': 4.15.0
-      bowser: 2.14.1
+      fast-xml-parser: 5.7.3
       tslib: 2.8.1
 
-  '@aws-sdk/util-user-agent-node@3.726.0':
-    dependencies:
-      '@aws-sdk/middleware-user-agent': 3.726.0
-      '@aws-sdk/types': 3.723.0
-      '@smithy/node-config-provider': 4.5.0
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
-  '@aws-sdk/xml-builder@3.723.0':
-    dependencies:
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
+  '@aws/lambda-invoke-store@0.2.4': {}
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -4261,6 +3809,8 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
+  '@nodable/entities@2.2.0': {}
+
   '@octokit/auth-token@6.0.0': {}
 
   '@octokit/core@7.0.6':
@@ -4559,11 +4109,6 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@smithy/config-resolver@4.6.0':
-    dependencies:
-      '@smithy/core': 3.25.0
-      tslib: 2.8.1
-
   '@smithy/core@3.25.0':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
@@ -4576,89 +4121,14 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
-  '@smithy/eventstream-serde-browser@4.4.0':
-    dependencies:
-      '@smithy/core': 3.25.0
-      tslib: 2.8.1
-
-  '@smithy/eventstream-serde-config-resolver@4.5.0':
-    dependencies:
-      '@smithy/core': 3.25.0
-      tslib: 2.8.1
-
-  '@smithy/eventstream-serde-node@4.4.0':
-    dependencies:
-      '@smithy/core': 3.25.0
-      tslib: 2.8.1
-
   '@smithy/fetch-http-handler@5.5.0':
     dependencies:
       '@smithy/core': 3.25.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
-  '@smithy/hash-blob-browser@4.4.0':
-    dependencies:
-      '@smithy/core': 3.25.0
-      tslib: 2.8.1
-
-  '@smithy/hash-node@4.4.0':
-    dependencies:
-      '@smithy/core': 3.25.0
-      tslib: 2.8.1
-
-  '@smithy/hash-stream-node@4.4.0':
-    dependencies:
-      '@smithy/core': 3.25.0
-      tslib: 2.8.1
-
-  '@smithy/invalid-dependency@4.4.0':
-    dependencies:
-      '@smithy/core': 3.25.0
-      tslib: 2.8.1
-
   '@smithy/is-array-buffer@2.2.0':
     dependencies:
-      tslib: 2.8.1
-
-  '@smithy/is-array-buffer@4.4.0':
-    dependencies:
-      '@smithy/core': 3.25.0
-      tslib: 2.8.1
-
-  '@smithy/md5-js@4.4.0':
-    dependencies:
-      '@smithy/core': 3.25.0
-      tslib: 2.8.1
-
-  '@smithy/middleware-content-length@4.4.0':
-    dependencies:
-      '@smithy/core': 3.25.0
-      tslib: 2.8.1
-
-  '@smithy/middleware-endpoint@4.6.0':
-    dependencies:
-      '@smithy/core': 3.25.0
-      tslib: 2.8.1
-
-  '@smithy/middleware-retry@4.7.0':
-    dependencies:
-      '@smithy/core': 3.25.0
-      tslib: 2.8.1
-
-  '@smithy/middleware-serde@4.4.0':
-    dependencies:
-      '@smithy/core': 3.25.0
-      tslib: 2.8.1
-
-  '@smithy/middleware-stack@4.4.0':
-    dependencies:
-      '@smithy/core': 3.25.0
-      tslib: 2.8.1
-
-  '@smithy/node-config-provider@4.5.0':
-    dependencies:
-      '@smithy/core': 3.25.0
       tslib: 2.8.1
 
   '@smithy/node-http-handler@4.8.0':
@@ -4667,28 +4137,7 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
-  '@smithy/property-provider@4.4.0':
-    dependencies:
-      '@smithy/core': 3.25.0
-      tslib: 2.8.1
-
-  '@smithy/protocol-http@5.5.0':
-    dependencies:
-      '@smithy/core': 3.25.0
-      tslib: 2.8.1
-
-  '@smithy/shared-ini-file-loader@4.6.0':
-    dependencies:
-      '@smithy/core': 3.25.0
-      tslib: 2.8.1
-
   '@smithy/signature-v4@5.5.0':
-    dependencies:
-      '@smithy/core': 3.25.0
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
-  '@smithy/smithy-client@4.14.0':
     dependencies:
       '@smithy/core': 3.25.0
       '@smithy/types': 4.15.0
@@ -4698,79 +4147,14 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/url-parser@4.4.0':
-    dependencies:
-      '@smithy/core': 3.25.0
-      tslib: 2.8.1
-
-  '@smithy/util-base64@4.5.0':
-    dependencies:
-      '@smithy/core': 3.25.0
-      tslib: 2.8.1
-
-  '@smithy/util-body-length-browser@4.4.0':
-    dependencies:
-      '@smithy/core': 3.25.0
-      tslib: 2.8.1
-
-  '@smithy/util-body-length-node@4.4.0':
-    dependencies:
-      '@smithy/core': 3.25.0
-      tslib: 2.8.1
-
   '@smithy/util-buffer-from@2.2.0':
     dependencies:
       '@smithy/is-array-buffer': 2.2.0
       tslib: 2.8.1
 
-  '@smithy/util-config-provider@4.4.0':
-    dependencies:
-      '@smithy/core': 3.25.0
-      tslib: 2.8.1
-
-  '@smithy/util-defaults-mode-browser@4.5.0':
-    dependencies:
-      '@smithy/core': 3.25.0
-      tslib: 2.8.1
-
-  '@smithy/util-defaults-mode-node@4.4.0':
-    dependencies:
-      '@smithy/core': 3.25.0
-      tslib: 2.8.1
-
-  '@smithy/util-endpoints@3.6.0':
-    dependencies:
-      '@smithy/core': 3.25.0
-      tslib: 2.8.1
-
-  '@smithy/util-middleware@4.4.0':
-    dependencies:
-      '@smithy/core': 3.25.0
-      tslib: 2.8.1
-
-  '@smithy/util-retry@4.5.0':
-    dependencies:
-      '@smithy/core': 3.25.0
-      tslib: 2.8.1
-
-  '@smithy/util-stream@4.7.0':
-    dependencies:
-      '@smithy/core': 3.25.0
-      tslib: 2.8.1
-
   '@smithy/util-utf8@2.3.0':
     dependencies:
       '@smithy/util-buffer-from': 2.2.0
-      tslib: 2.8.1
-
-  '@smithy/util-utf8@4.4.0':
-    dependencies:
-      '@smithy/core': 3.25.0
-      tslib: 2.8.1
-
-  '@smithy/util-waiter@4.5.0':
-    dependencies:
-      '@smithy/core': 3.25.0
       tslib: 2.8.1
 
   '@types/argparse@1.0.38': {}
@@ -4967,6 +4351,8 @@ snapshots:
   ansi-styles@6.2.3: {}
 
   any-promise@1.3.0: {}
+
+  anynum@1.0.0: {}
 
   archiver-utils@5.0.2:
     dependencies:
@@ -5540,9 +4926,17 @@ snapshots:
 
   fast-uri@3.1.2: {}
 
-  fast-xml-parser@4.4.1:
+  fast-xml-builder@1.2.0:
     dependencies:
-      strnum: 1.1.2
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.7.3:
+    dependencies:
+      '@nodable/entities': 2.2.0
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.4.0
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -6095,6 +5489,8 @@ snapshots:
 
   path-exists@3.0.0: {}
 
+  path-expression-matcher@1.5.0: {}
+
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
@@ -6475,7 +5871,9 @@ snapshots:
 
   strip-json-comments@2.0.1: {}
 
-  strnum@1.1.2: {}
+  strnum@2.4.0:
+    dependencies:
+      anynum: 1.0.0
 
   super-regex@1.1.0:
     dependencies:
@@ -6826,6 +6224,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   xdg-basedir@5.1.0: {}
+
+  xml-naming@0.1.0: {}
 
   xtend@4.0.2: {}
 

--- a/tests/helpers/s3-client-factory.ts
+++ b/tests/helpers/s3-client-factory.ts
@@ -1,8 +1,12 @@
 import { S3Client } from '@aws-sdk/client-s3';
-import type { FlociConfig } from '../medium/setup/global-setup';
+import type { TestS3Config } from '../medium/setup/global-setup';
 
-export const createTestS3Client = (config: FlociConfig): S3Client =>
-  new S3Client({
+export const createTestS3Client = (config: TestS3Config): S3Client => {
+  if (config.mode === 'aws') {
+    // Use the ambient AWS SDK credential chain (env vars, IMDS, aws-vault, ...).
+    return new S3Client({ region: config.region });
+  }
+  return new S3Client({
     endpoint: config.endpoint,
     region: config.region,
     forcePathStyle: true,
@@ -11,3 +15,4 @@ export const createTestS3Client = (config: FlociConfig): S3Client =>
       secretAccessKey: config.secretAccessKey,
     },
   });
+};

--- a/tests/helpers/s3-helper.ts
+++ b/tests/helpers/s3-helper.ts
@@ -1,10 +1,16 @@
 import { randomUUID } from 'node:crypto';
 import {
+  AbortMultipartUploadCommand,
   CreateBucketCommand,
+  DeleteBucketCommand,
+  DeleteObjectsCommand,
+  ListMultipartUploadsCommand,
+  ListObjectsV2Command,
   PutObjectCommand,
   type S3Client,
 } from '@aws-sdk/client-s3';
 import pLimit from 'p-limit';
+import { onTestFinished } from 'vitest';
 
 const limit = pLimit(10);
 
@@ -30,6 +36,10 @@ export class S3ClientHelper {
         Bucket: bucketName,
       })
     );
+
+    // Real AWS buckets cost money and Floci's container is recreated per run,
+    // but the cleanup hook is cheap in both cases and keeps real-S3 mode safe.
+    onTestFinished(() => this.cleanupBucket(bucketName));
 
     const promises = params.files.flatMap((file, i) => {
       const fileContent = Buffer.alloc(file.fileSize, file.fill ?? '0');
@@ -57,5 +67,63 @@ export class S3ClientHelper {
         Body: body,
       })
     );
+  }
+
+  private async cleanupBucket(bucketName: string): Promise<void> {
+    // Abort lingering multipart uploads first so DeleteBucket isn't blocked.
+    let uploadIdMarker: string | undefined;
+    let keyMarker: string | undefined;
+    do {
+      const resp = await this.s3Client.send(
+        new ListMultipartUploadsCommand({
+          Bucket: bucketName,
+          KeyMarker: keyMarker,
+          UploadIdMarker: uploadIdMarker,
+        })
+      );
+      for (const u of resp.Uploads ?? []) {
+        if (u.Key === undefined || u.UploadId === undefined) continue;
+        await this.s3Client.send(
+          new AbortMultipartUploadCommand({
+            Bucket: bucketName,
+            Key: u.Key,
+            UploadId: u.UploadId,
+          })
+        );
+      }
+      if (resp.IsTruncated) {
+        keyMarker = resp.NextKeyMarker;
+        uploadIdMarker = resp.NextUploadIdMarker;
+      } else {
+        keyMarker = undefined;
+        uploadIdMarker = undefined;
+      }
+    } while (keyMarker !== undefined);
+
+    let continuationToken: string | undefined;
+    do {
+      const resp = await this.s3Client.send(
+        new ListObjectsV2Command({
+          Bucket: bucketName,
+          ContinuationToken: continuationToken,
+        })
+      );
+      const objects = (resp.Contents ?? [])
+        .map((c) => c.Key)
+        .filter((k): k is string => k !== undefined);
+      if (objects.length > 0) {
+        await this.s3Client.send(
+          new DeleteObjectsCommand({
+            Bucket: bucketName,
+            Delete: { Objects: objects.map((Key) => ({ Key })) },
+          })
+        );
+      }
+      continuationToken = resp.IsTruncated
+        ? resp.NextContinuationToken
+        : undefined;
+    } while (continuationToken !== undefined);
+
+    await this.s3Client.send(new DeleteBucketCommand({ Bucket: bucketName }));
   }
 }

--- a/tests/medium/s3-concat.test.ts
+++ b/tests/medium/s3-concat.test.ts
@@ -5,7 +5,7 @@ import { KiB, MiB } from '../../lib/std/storage-size';
 import { createTestS3Client } from '../helpers/s3-client-factory';
 import { S3ClientHelper } from '../helpers/s3-helper';
 
-const FLOCI_CONFIG = inject('flociConfig');
+const TEST_S3_CONFIG = inject('testS3Config');
 
 describe('concat', () => {
   test('SingleFileOutputWithoutMinSize', async () => {
@@ -23,7 +23,7 @@ describe('concat', () => {
     const prefix = 'tmp';
     const dstPrefix = 'output';
     const concatFileName = 'output.json';
-    const s3Client = createTestS3Client(FLOCI_CONFIG);
+    const s3Client = createTestS3Client(TEST_S3_CONFIG);
     const s3ClientHelper = new S3ClientHelper(s3Client);
     const { bucketName } = await s3ClientHelper.setupS3({
       files,
@@ -58,13 +58,13 @@ describe('concat', () => {
       })
     );
     expect(got.Contents).toEqual([
-      {
+      expect.objectContaining({
         ETag: expect.any(String),
         Key: `${dstPrefix}/${concatFileName}`,
         LastModified: expect.any(Date),
         Size: 1000 * KiB * 11 + 5 * MiB * 3,
         StorageClass: 'STANDARD',
-      },
+      }),
     ]);
   });
 
@@ -82,7 +82,7 @@ describe('concat', () => {
     ];
     const prefix = 'tmp';
     const dstPrefix = 'output';
-    const s3Client = createTestS3Client(FLOCI_CONFIG);
+    const s3Client = createTestS3Client(TEST_S3_CONFIG);
     const s3ClientHelper = new S3ClientHelper(s3Client);
     const { bucketName } = await s3ClientHelper.setupS3({
       files,
@@ -138,48 +138,48 @@ describe('concat', () => {
       })
     );
     expect(got.Contents).toEqual([
-      {
+      expect.objectContaining({
         Key: 'output/concat_1.json',
         LastModified: expect.any(Date),
         ETag: expect.any(String),
         Size: 3 * KiB,
         StorageClass: 'STANDARD',
-      },
-      {
+      }),
+      expect.objectContaining({
         Key: 'output/concat_2.json',
         LastModified: expect.any(Date),
         ETag: expect.any(String),
         Size: 3 * KiB,
         StorageClass: 'STANDARD',
-      },
-      {
+      }),
+      expect.objectContaining({
         Key: 'output/concat_3.json',
         LastModified: expect.any(Date),
         ETag: expect.any(String),
         Size: 3 * KiB,
         StorageClass: 'STANDARD',
-      },
-      {
+      }),
+      expect.objectContaining({
         Key: 'output/concat_4.json',
         LastModified: expect.any(Date),
         ETag: expect.any(String),
         Size: 1 * KiB + 5 * MiB,
         StorageClass: 'STANDARD',
-      },
-      {
+      }),
+      expect.objectContaining({
         Key: 'output/concat_5.json',
         LastModified: expect.any(Date),
         ETag: expect.any(String),
         Size: 5 * MiB,
         StorageClass: 'STANDARD',
-      },
-      {
+      }),
+      expect.objectContaining({
         Key: 'output/concat_6.json',
         LastModified: expect.any(Date),
         ETag: expect.any(String),
         Size: 5 * MiB,
         StorageClass: 'STANDARD',
-      },
+      }),
     ]);
   });
 
@@ -215,7 +215,7 @@ describe('concat', () => {
       ];
       const prefix = 'tmp';
       const dstPrefix = 'output';
-      const s3Client = createTestS3Client(FLOCI_CONFIG);
+      const s3Client = createTestS3Client(TEST_S3_CONFIG);
       const s3ClientHelper = new S3ClientHelper(s3Client);
       const { bucketName } = await s3ClientHelper.setupS3({
         files,
@@ -251,13 +251,13 @@ describe('concat', () => {
         })
       );
       expect(got.Contents).toEqual([
-        {
+        expect.objectContaining({
           Key: 'output/concat_1.json',
           LastModified: expect.any(Date),
           ETag: expect.any(String),
           Size: 8,
           StorageClass: 'STANDARD',
-        },
+        }),
       ]);
 
       const fileContent = await s3Client.send(
@@ -291,7 +291,7 @@ describe('concat', () => {
     ];
     const prefix = 'tmp';
     const dstPrefix = 'output';
-    const s3Client = createTestS3Client(FLOCI_CONFIG);
+    const s3Client = createTestS3Client(TEST_S3_CONFIG);
     const s3ClientHelper = new S3ClientHelper(s3Client);
     const { bucketName } = await s3ClientHelper.setupS3({
       files,
@@ -328,13 +328,13 @@ describe('concat', () => {
       })
     );
     expect(got.Contents).toEqual([
-      {
+      expect.objectContaining({
         Key: 'output/concat_1.json',
         LastModified: expect.any(Date),
         ETag: expect.any(String),
         Size: 8,
         StorageClass: 'STANDARD',
-      },
+      }),
     ]);
 
     const fileContent = await s3Client.send(
@@ -351,7 +351,7 @@ describe('concat', () => {
     // Given:
     const prefix = 'tmp';
     const dstPrefix = 'output';
-    const s3Client = createTestS3Client(FLOCI_CONFIG);
+    const s3Client = createTestS3Client(TEST_S3_CONFIG);
     const s3ClientHelper = new S3ClientHelper(s3Client);
     const { bucketName } = await s3ClientHelper.setupS3({
       files: [],

--- a/tests/medium/s3/client.test.ts
+++ b/tests/medium/s3/client.test.ts
@@ -3,12 +3,12 @@ import { getListFiles } from '../../../lib/s3/client';
 import { createTestS3Client } from '../../helpers/s3-client-factory';
 import { S3ClientHelper } from '../../helpers/s3-helper';
 
-const FLOCI_CONFIG = inject('flociConfig');
+const TEST_S3_CONFIG = inject('testS3Config');
 
 describe('getListFiles', () => {
   test('ListFilesWithPrefix', async () => {
     // Given:
-    const s3Client = createTestS3Client(FLOCI_CONFIG);
+    const s3Client = createTestS3Client(TEST_S3_CONFIG);
     const s3ClientHelper = new S3ClientHelper(s3Client);
     const prefix = 'tmp';
     const { bucketName } = await s3ClientHelper.setupS3({

--- a/tests/medium/setup/global-setup.ts
+++ b/tests/medium/setup/global-setup.ts
@@ -4,35 +4,50 @@ import {
 } from '@floci/testcontainers';
 import type { GlobalSetupContext } from 'vitest/node';
 
-export type FlociConfig = {
-  endpoint: string;
-  region: string;
-  accessKeyId: string;
-  secretAccessKey: string;
-};
+export type TestS3Config =
+  | {
+      mode: 'floci';
+      endpoint: string;
+      region: string;
+      accessKeyId: string;
+      secretAccessKey: string;
+    }
+  | {
+      mode: 'aws';
+      region: string;
+    };
 
 declare module 'vitest' {
   export interface ProvidedContext {
-    flociConfig: FlociConfig;
+    testS3Config: TestS3Config;
   }
 }
 
-let container: StartedFlociContainer;
+let container: StartedFlociContainer | undefined;
 
 export const setup = async ({ provide }: GlobalSetupContext) => {
-  container = await new FlociContainer().start();
+  if (process.env.USE_REAL_S3 === '1') {
+    const region =
+      process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION ?? 'us-east-1';
+    provide('testS3Config', { mode: 'aws', region });
+    console.log(`using real AWS S3 (region=${region})`);
+    return;
+  }
 
-  provide('flociConfig', {
+  container = await new FlociContainer().start();
+  provide('testS3Config', {
+    mode: 'floci',
     endpoint: container.getEndpoint(),
     region: container.getRegion(),
     accessKeyId: container.getAccessKey(),
     secretAccessKey: container.getSecretKey(),
   });
-
   console.log('container launched');
 };
 
 export const teardown = async () => {
-  await container.stop();
-  console.log('container stopped');
+  if (container !== undefined) {
+    await container.stop();
+    console.log('container stopped');
+  }
 };


### PR DESCRIPTION
## Summary

- `createCombinedStream` forwarded each `GetObject.Body` chunk straight into `UploadPartCommand`. With newer `@aws-sdk/client-s3` releases that no longer auto-buffer the request body, small source chunks become their own SigV4 chunked-encoding frames and real S3 rejects sub-8192-byte frames with `InvalidChunkSizeError`.
- floci/LocalStack don't enforce the rule and 1.3.0's bundled SDK (3.726.0) silently buffered, so the existing integration suite never caught it.
- Fix: coalesce pending bytes inside the async generator and only yield once they reach 64 KiB. The last partial chunk is still flushed because S3 allows the final frame to be smaller.

## Reproduction approach

Rather than add a new test, the existing `tests/medium/s3-concat.test.ts` suite is now switchable between floci (default) and real AWS S3 via `USE_REAL_S3=1`. Combined with bumping `@aws-sdk/client-s3` devDep to `3.1070.0` (the version that exposes the regression), the same scenarios reproduce the bug end-to-end.

```bash
# floci (CI default, unchanged)
pnpm test

# real AWS S3 — requires ambient AWS creds + AWS_REGION
pnpm e2e
```

Buckets are cleaned up automatically: `S3ClientHelper.setupS3` registers an `onTestFinished` hook that aborts lingering multipart uploads, batch-deletes all objects, then deletes the bucket.

## Evidence

Captured on `us-east-1` with `@aws-sdk/client-s3@3.1070.0`.

**Without the fix** (`main`'s `lib/s3/client.ts`):

```
 FAIL  |medium| tests/medium/s3-concat.test.ts > concat > SingleFileOutputWithoutMinSize
 FAIL  |medium| tests/medium/s3-concat.test.ts > concat > SplitAndMergeWithMinSize
 FAIL  |medium| tests/medium/s3-concat.test.ts > concat > 'KeyNameAscConcat' > concat test
 FAIL  |medium| tests/medium/s3-concat.test.ts > concat > 'KeyNameDscConcat' > concat test
 FAIL  |medium| tests/medium/s3-concat.test.ts > concat > CustomJoinOrderConcat

InvalidChunkSizeError: Only the last chunk is allowed to have a size less than 8192 bytes.
Set [requestStreamBufferSize=number e.g. 65_536] in client constructor to instruct AWS SDK
to buffer your input stream.

 Test Files  1 failed | 3 passed (4)
      Tests  5 failed | 13 passed (18)
   Duration  44.98s
```

**With the fix** (this branch):

```
 ✓ |medium| tests/medium/s3-concat.test.ts > concat > SingleFileOutputWithoutMinSize 50016ms
 ✓ |medium| tests/medium/s3-concat.test.ts > concat > SplitAndMergeWithMinSize 11543ms
 ✓ |medium| tests/medium/s3-concat.test.ts > concat > 'KeyNameAscConcat' > concat test 5517ms
 ✓ |medium| tests/medium/s3-concat.test.ts > concat > 'KeyNameDscConcat' > concat test 5185ms
 ✓ |medium| tests/medium/s3-concat.test.ts > concat > CustomJoinOrderConcat 4964ms
 ✓ |medium| tests/medium/s3-concat.test.ts > concat > NotFoundFile 2065ms

 Test Files  4 passed (4)
      Tests  18 passed (18)
   Duration  79.98s
```

