### PR TITLE
fix: collect part bytes into a Buffer instead of streaming

### DIFF
--- a/lib/s3/client.ts
+++ b/lib/s3/client.ts
@@ -1,4 +1,3 @@
-import { Readable } from 'node:stream';
 import {
   CompleteMultipartUploadCommand,
   CreateMultipartUploadCommand,
@@ -67,54 +66,44 @@ export const getListFiles = async (
 const encodeCopySourceKey = (key: string): string =>
   key.split('/').map(encodeURIComponent).join('/');
 
-// S3's SigV4 chunked transfer encoding requires every non-final chunk to be
-// at least 8192 bytes. GetObject bodies of small source files can yield
-// chunks well below that, which makes UploadPartCommand fail with
-// InvalidChunkSizeError against real S3 (LocalStack/floci don't enforce it).
-// Coalesce yielded buffers up to MIN_STREAM_CHUNK before passing them on;
-// the very last chunk is allowed to be smaller and is flushed at the end.
-const MIN_STREAM_CHUNK = 64 * 1024;
-
-const createCombinedStream = (
+// Collect all source-file bytes for one PartTask into a single Buffer.
+//
+// UploadPartCommand selects its wire encoding based on the Body type:
+// a Buffer payload is sent with a known Content-Length (single-chunk
+// SigV4), while a Readable triggers aws-chunked streaming, which S3
+// gates on a 8192-byte minimum per non-final chunk. Streaming would
+// make us depend on the consumer's @aws-sdk/client-s3 version (3.97x+
+// stopped buffering input streams internally, so small GetObject body
+// chunks reach the wire intact and S3 rejects them). Collecting into
+// a Buffer sidesteps the chunked path entirely.
+//
+// Memory cost is bounded by S3 itself: planedUploadTask caps each
+// PartTask at PART_UPLOAD_LIMIT (5 MiB), so even with a saturated
+// pLimit the in-flight peak is roughly partSize * concurrency.
+const collectPartBytes = async (
   s3Client: S3Client,
   s3Files: S3File[],
   bucketName: string
-): Readable =>
-  Readable.from(
-    (async function* () {
-      const pending: Buffer[] = [];
-      let pendingSize = 0;
-
-      for (const f of s3Files) {
-        const range = `bytes=${f.start}-${f.size - 1}`;
-        const getRes = await s3Client.send(
-          new GetObjectCommand({
-            Bucket: bucketName,
-            Key: f.key,
-            Range: range,
-          })
-        );
-
-        const body = getRes.Body;
-        if (body === undefined) {
-          throw new Error(`empty body for s3://${bucketName}/${f.key}`);
-        }
-        for await (const chunk of body as Readable) {
-          const buf = chunk as Buffer;
-          pending.push(buf);
-          pendingSize += buf.length;
-          if (pendingSize >= MIN_STREAM_CHUNK) {
-            yield Buffer.concat(pending, pendingSize);
-            pending.length = 0;
-            pendingSize = 0;
-          }
-        }
-      }
-      if (pendingSize > 0) {
-        yield Buffer.concat(pending, pendingSize);
-      }
-    })()
-  );
+): Promise<Buffer> => {
+  const parts: Buffer[] = [];
+  for (const f of s3Files) {
+    const range = `bytes=${f.start}-${f.size - 1}`;
+    const getRes = await s3Client.send(
+      new GetObjectCommand({
+        Bucket: bucketName,
+        Key: f.key,
+        Range: range,
+      })
+    );
+    const body = getRes.Body;
+    if (body === undefined) {
+      throw new Error(`empty body for s3://${bucketName}/${f.key}`);
+    }
+    const bytes = await body.transformToByteArray();
+    parts.push(Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength));
+  }
+  return Buffer.concat(parts);
+};
 
 export const concatWithMultipartUpload = async (
   s3Client: S3Client,
@@ -171,7 +160,7 @@ export const concatWithMultipartUpload = async (
           return;
         }
 
-        const partStream = createCombinedStream(
+        const partBytes = await collectPartBytes(
           s3Client,
           task.s3Files,
           bucketName
@@ -183,8 +172,8 @@ export const concatWithMultipartUpload = async (
             Key: newKey,
             UploadId: uploadId,
             PartNumber: partNumber,
-            Body: partStream,
-            ContentLength: partSize,
+            Body: partBytes,
+            ContentLength: partBytes.length,
           })
         );
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "check:spell": "cspell lint . --cache --gitignore",
     "clean": "rimraf dist",
     "test": "vitest run --config vitest.config.ts --coverage.enabled true --reporter=verbose",
+    "test:sdk-matrix": "bash scripts/sdk-matrix.sh test",
     "e2e": "USE_REAL_S3=1 vitest run --config vitest.config.ts --reporter=verbose",
+    "e2e:sdk-matrix": "bash scripts/sdk-matrix.sh e2e",
     "publish": "semantic-release"
   },
   "author": "shuntaka9576",

--- a/scripts/sdk-matrix.sh
+++ b/scripts/sdk-matrix.sh
@@ -6,7 +6,7 @@
 #   scripts/sdk-matrix.sh [test|e2e]
 #
 #   test  - run `pnpm test` (floci, default)
-#   e2e   - run `pnpm e2e`  (real AWS S3; requires ambient creds)
+#   e2e   - run `pnpm e2e`  (real AWS S3; requires ambient credentials)
 #
 # Override versions with: SDK_VERSIONS="3.726.0 latest" scripts/sdk-matrix.sh
 set -euo pipefail

--- a/scripts/sdk-matrix.sh
+++ b/scripts/sdk-matrix.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Run the test suite against several @aws-sdk/client-s3 versions, then
+# restore the original lockfile state.
+#
+# Usage:
+#   scripts/sdk-matrix.sh [test|e2e]
+#
+#   test  - run `pnpm test` (floci, default)
+#   e2e   - run `pnpm e2e`  (real AWS S3; requires ambient creds)
+#
+# Override versions with: SDK_VERSIONS="3.726.0 latest" scripts/sdk-matrix.sh
+set -euo pipefail
+
+MODE="${1:-test}"
+case "$MODE" in
+  test) PNPM_CMD=(pnpm test) ;;
+  e2e)  PNPM_CMD=(pnpm e2e) ;;
+  *)
+    echo "Usage: $0 [test|e2e]" >&2
+    exit 2
+    ;;
+esac
+
+read -r -a SDK_VERSIONS <<<"${SDK_VERSIONS:-3.726.0 3.1070.0 latest}"
+
+BACKUP_DIR=$(mktemp -d)
+cp package.json pnpm-lock.yaml "$BACKUP_DIR/"
+
+restore() {
+  printf '\n--- Restoring original package.json / pnpm-lock.yaml ---\n'
+  cp "$BACKUP_DIR/package.json" "$BACKUP_DIR/pnpm-lock.yaml" .
+  pnpm install --frozen-lockfile >/dev/null
+  rm -rf "$BACKUP_DIR"
+}
+trap restore EXIT
+
+passed=()
+failed=()
+for v in "${SDK_VERSIONS[@]}"; do
+  printf '\n=== @aws-sdk/client-s3@%s (mode=%s) ===\n' "$v" "$MODE"
+  pnpm add -D --save-exact "@aws-sdk/client-s3@${v}" >/dev/null
+  if "${PNPM_CMD[@]}"; then
+    passed+=("$v")
+  else
+    failed+=("$v")
+  fi
+done
+
+printf '\n--- summary ---\n'
+[ ${#passed[@]} -gt 0 ] && printf 'PASS: %s\n' "${passed[*]}"
+[ ${#failed[@]} -gt 0 ] && printf 'FAIL: %s\n' "${failed[*]}"
+
+if [ ${#failed[@]} -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Follow-up to #12. PR #12 stayed on the aws-chunked code path and just coalesced our generator yields to >= 64 KiB so each wire chunk would clear S3's 8192-byte minimum. That fix works today but leaves the library coupled to whatever request-body handling the consumer's `@aws-sdk/client-s3` happens to do.
- This PR sidesteps the chunked path entirely. `UploadPartCommand` picks single-chunk SigV4 when `Body` is a `Buffer` (Content-Length known up front), so the 8192-byte rule no longer applies and behavior is invariant across SDK versions / `requestStreamBufferSize` settings.
- Read each `PartTask`'s source bytes via `GetObject.Body.transformToByteArray()`, concat into one `Buffer`, hand that to `UploadPartCommand`. `planedUploadTask` already caps a part at 5 MiB so peak memory is bounded by `partSize * pLimit` (~25 MiB at the default `pLimit: 5`).
- Also adds `scripts/sdk-matrix.sh` plus `pnpm test:sdk-matrix` / `pnpm e2e:sdk-matrix` so contributors can verify the fix locally across `@aws-sdk/client-s3` versions without expanding per-PR CI.

## Why this isn't just a style change

The chunked-vs-single-chunk choice happens *inside the SDK*, based on Body type. We have no control over the SDK or the consumer's S3Client config from inside the library. By providing a `Buffer`, we deterministically take the single-chunk branch — that branch has no minimum-chunk rule, no `requestStreamBufferSize` interaction, no streaming buffer behavior to depend on.

## Trade-offs

|  | PR #12 (stream + 64 KiB coalesce) | this PR (Buffer body) |
|---|---|---|
| SigV4 path | aws-chunked (B mode) | single-chunk (A mode) |
| 8192-byte min chunk rule | applies (we satisfy it) | does not apply |
| Behavior across SDK versions | depends on SDK preserving our chunk boundaries | invariant |
| Peak memory per PartCommand | ~64 KiB | <= 5 MiB |
| Total peak (pLimit=5) | ~320 KiB | ~25 MiB |

## Verification

All runs against `us-east-1`. Buckets are created and cleaned up by the
`onTestFinished` hook introduced in #12 — no leaked resources after either run.

### Buffer body fix on this branch — `pnpm e2e:sdk-matrix`

```
=== @aws-sdk/client-s3@3.726.0 (mode=e2e) ===
 Test Files  4 passed (4)
   Duration  68.15s

=== @aws-sdk/client-s3@3.1070.0 (mode=e2e) ===
 Test Files  4 passed (4)
   Duration  60.73s

=== @aws-sdk/client-s3@latest (mode=e2e) ===
 Test Files  4 passed (4)
   Duration  68.82s

--- summary ---
PASS: 3.726.0 3.1070.0 latest
```

### Pre-fix (raw stream pass-through, equivalent to 1.3.0 lib/s3/client.ts) — same matrix

```
=== @aws-sdk/client-s3@3.726.0 (mode=e2e) ===
 Test Files  4 passed (4)
   Duration  69.39s

=== @aws-sdk/client-s3@3.1070.0 (mode=e2e) ===
InvalidChunkSizeError: Only the last chunk is allowed to have a size less than 8192 bytes.
Set [requestStreamBufferSize=number e.g. 65_536] in client constructor to instruct AWS SDK
to buffer your input stream.
 Test Files  1 failed | 3 passed (4)
   Duration  33.75s

=== @aws-sdk/client-s3@latest (mode=e2e) ===
InvalidChunkSizeError: Only the last chunk is allowed to have a size less than 8192 bytes.
 Test Files  1 failed | 3 passed (4)
   Duration  45.79s

--- summary ---
PASS: 3.726.0
FAIL: 3.1070.0 latest
```

That's the clean before/after: 3.726.0 hides the bug because the old SDK still buffered request streams; 3.1070.0 and `latest` send chunks through verbatim and S3 rejects them. With this PR's Buffer body change all three versions pass because the request never enters aws-chunked encoding to begin with.


