### PR TITLE
docs: add npm version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![ci](https://github.com/shuntaka9576/s3-concat/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/shuntaka9576/s3-concat/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/shuntaka9576/s3-concat/graph/badge.svg?token=ES0V32EAHO)](https://codecov.io/gh/shuntaka9576/s3-concat)
+[![ci](https://github.com/shuntaka9576/s3-concat/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/shuntaka9576/s3-concat/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/shuntaka9576/s3-concat/graph/badge.svg?token=ES0V32EAHO)](https://codecov.io/gh/shuntaka9576/s3-concat) [![npm version](https://img.shields.io/npm/v/s3-concat.svg)](https://www.npmjs.com/package/s3-concat)
 
 # s3-concat
 


### PR DESCRIPTION
## Summary
- Add the npm version badge (with link to the npmjs.com package page) to the top of `README.md`, alongside the existing CI and codecov badges.

## Changes
- `README.md`: Append `[![npm version](https://img.shields.io/npm/v/s3-concat.svg)](https://www.npmjs.com/package/s3-concat)` to the badge row.

## Test plan
- [x] Confirm the npm version badge renders on the GitHub README preview.
- [x] Confirm the badge links to https://www.npmjs.com/package/s3-concat.
