### PR TITLE
fix: return fileNotFound/allEmpty for empty input

### DIFF
--- a/lib/s3-concat.ts
+++ b/lib/s3-concat.ts
@@ -32,8 +32,10 @@ type ConcatResult =
   | {
       kind: 'concatenated';
       keys: { key: string; size: number }[];
+      skippedEmptyKeys: string[];
     }
-  | { kind: 'fileNotFound' };
+  | { kind: 'fileNotFound' }
+  | { kind: 'allEmpty'; emptyKeys: string[] };
 
 export type ConcatParams = {
   /**
@@ -175,14 +177,18 @@ export class S3Concat {
     this.s3Files.push(...files);
   }
 
-  private toS3Files(): { files: Deque<S3File>; size: number } {
-    if (this.joinOrder !== 'fetchOrder') {
-      this.s3Files = this.s3Files.sort(this.joinOrder);
-    }
+  private toS3Files(entries: S3FileMeta[]): {
+    files: Deque<S3File>;
+    size: number;
+  } {
+    const sorted =
+      this.joinOrder === 'fetchOrder'
+        ? entries
+        : [...entries].sort(this.joinOrder);
 
     const s3Files = new Deque<S3File>();
     let size = 0;
-    for (const s3File of this.s3Files) {
+    for (const s3File of sorted) {
       s3Files.pushBack(new S3File(s3File.key, s3File.size, 0));
       size += s3File.size;
     }
@@ -191,7 +197,25 @@ export class S3Concat {
   }
 
   async concat(): Promise<ConcatResult> {
-    const s3Files = this.toS3Files();
+    if (this.s3Files.length === 0) {
+      return { kind: 'fileNotFound' };
+    }
+
+    const emptyKeys: string[] = [];
+    const nonEmpty: S3FileMeta[] = [];
+    for (const f of this.s3Files) {
+      if (f.size === 0) {
+        emptyKeys.push(f.key);
+      } else {
+        nonEmpty.push(f);
+      }
+    }
+
+    if (nonEmpty.length === 0) {
+      return { kind: 'allEmpty', emptyKeys };
+    }
+
+    const s3Files = this.toS3Files(nonEmpty);
     const splitFiles = planedSplitFiles(
       this.concatFileNameCallback,
       s3Files,
@@ -207,10 +231,6 @@ export class S3Concat {
       uploadTasks: planedUploadTask(splitFile.s3Files.files),
       size: splitFile.s3Files.size,
     }));
-
-    if (splitFileAndUploadTask.length === 0) {
-      return { kind: 'fileNotFound' };
-    }
 
     const limit = pLimit(this.limitConcurrency);
 
@@ -236,6 +256,7 @@ export class S3Concat {
     return {
       kind: 'concatenated',
       keys,
+      skippedEmptyKeys: emptyKeys,
     };
   }
 }

--- a/tests/medium/s3-concat.test.ts
+++ b/tests/medium/s3-concat.test.ts
@@ -50,6 +50,7 @@ describe('concat', () => {
         },
       ],
       kind: 'concatenated',
+      skippedEmptyKeys: [],
     });
     const got = await s3Client.send(
       new ListObjectsV2Command({
@@ -130,6 +131,7 @@ describe('concat', () => {
         },
       ],
       kind: 'concatenated',
+      skippedEmptyKeys: [],
     });
     const got = await s3Client.send(
       new ListObjectsV2Command({
@@ -242,6 +244,7 @@ describe('concat', () => {
           },
         ],
         kind: 'concatenated',
+        skippedEmptyKeys: [],
       });
 
       const got = await s3Client.send(
@@ -320,6 +323,7 @@ describe('concat', () => {
         },
       ],
       kind: 'concatenated',
+      skippedEmptyKeys: [],
     });
     const got = await s3Client.send(
       new ListObjectsV2Command({
@@ -373,5 +377,140 @@ describe('concat', () => {
     expect(result).toEqual({
       kind: 'fileNotFound',
     });
+  });
+
+  test('NotFoundFileWithoutMinSize', async () => {
+    // Given:
+    const prefix = 'tmp/does-not-exist';
+    const dstPrefix = 'output';
+    const s3Client = createTestS3Client(TEST_S3_CONFIG);
+    const s3ClientHelper = new S3ClientHelper(s3Client);
+    const { bucketName } = await s3ClientHelper.setupS3({
+      files: [],
+      prefix,
+    });
+
+    // When:
+    const s3Concat = new S3Concat({
+      s3Client,
+      srcBucketName: bucketName,
+      dstBucketName: bucketName,
+      dstPrefix,
+      concatFileName: 'never.txt',
+    });
+    await s3Concat.addFiles(prefix);
+    const result = await s3Concat.concat();
+
+    // Then:
+    expect(result).toEqual({
+      kind: 'fileNotFound',
+    });
+  });
+
+  test('AllEmpty', async () => {
+    // Given:
+    const prefix = 'tmp';
+    const dstPrefix = 'output';
+    const s3Client = createTestS3Client(TEST_S3_CONFIG);
+    const s3ClientHelper = new S3ClientHelper(s3Client);
+    const { bucketName } = await s3ClientHelper.setupS3({
+      files: [
+        {
+          fileSize: 0,
+          fileCount: 3,
+        },
+      ],
+      prefix,
+    });
+
+    // When:
+    const s3Concat = new S3Concat({
+      s3Client,
+      srcBucketName: bucketName,
+      dstBucketName: bucketName,
+      dstPrefix,
+      concatFileName: 'never.txt',
+    });
+    await s3Concat.addFiles(prefix);
+    const result = await s3Concat.concat();
+
+    // Then:
+    expect(result).toEqual({
+      kind: 'allEmpty',
+      emptyKeys: expect.arrayContaining([
+        `${prefix}/file-1-1.txt`,
+        `${prefix}/file-1-2.txt`,
+        `${prefix}/file-1-3.txt`,
+      ]),
+    });
+    if (result.kind === 'allEmpty') {
+      expect(result.emptyKeys).toHaveLength(3);
+    }
+  });
+
+  test('MixedWithEmpty', async () => {
+    // Given:
+    const prefix = 'tmp';
+    const dstPrefix = 'output';
+    const concatFileName = 'output.json';
+    const s3Client = createTestS3Client(TEST_S3_CONFIG);
+    const s3ClientHelper = new S3ClientHelper(s3Client);
+    const { bucketName } = await s3ClientHelper.setupS3({
+      files: [
+        {
+          fileSize: 1000 * KiB,
+          fileCount: 2,
+        },
+        {
+          fileSize: 0,
+          fileCount: 2,
+        },
+      ],
+      prefix,
+    });
+
+    // When:
+    const s3Concat = new S3Concat({
+      s3Client,
+      srcBucketName: bucketName,
+      dstBucketName: bucketName,
+      dstPrefix,
+      concatFileName,
+    });
+    await s3Concat.addFiles(prefix);
+    const result = await s3Concat.concat();
+
+    // Then:
+    expect(result).toEqual({
+      kind: 'concatenated',
+      keys: [
+        {
+          key: `${dstPrefix}/${concatFileName}`,
+          size: 1000 * KiB * 2,
+        },
+      ],
+      skippedEmptyKeys: expect.arrayContaining([
+        `${prefix}/file-2-1.txt`,
+        `${prefix}/file-2-2.txt`,
+      ]),
+    });
+    if (result.kind === 'concatenated') {
+      expect(result.skippedEmptyKeys).toHaveLength(2);
+    }
+    const got = await s3Client.send(
+      new ListObjectsV2Command({
+        Bucket: bucketName,
+        Prefix: dstPrefix,
+      })
+    );
+    expect(got.Contents).toEqual([
+      expect.objectContaining({
+        Key: `${dstPrefix}/${concatFileName}`,
+        LastModified: expect.any(Date),
+        ETag: expect.any(String),
+        Size: 1000 * KiB * 2,
+        StorageClass: 'STANDARD',
+      }),
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- `concat()` previously triggered `MalformedXML` from S3 when called with a prefix that matched no objects, or a prefix containing only size 0 objects, because an empty `MultipartUpload` was issued.
- Now returns `{ kind: 'fileNotFound' }` for zero matches and a new `{ kind: 'allEmpty', emptyKeys }` when all matches are size 0. Mixed inputs concatenate the non-empty files and surface the dropped keys via `concatenated.skippedEmptyKeys`.

## Type changes (`ConcatResult`)
- `concatenated`: adds `skippedEmptyKeys: string[]`
- New kind `allEmpty` with `emptyKeys: string[]`
- `fileNotFound` keeps the existing meaning (no objects matched)

Note: adding a new kind is a minor breaking change for callers that exhaustively switch on `kind`; existing properties on `concatenated` are unchanged.

## Changes
- `lib/s3-concat.ts`
  - Short-circuit `concat()` when `s3Files.length === 0`.
  - Partition `s3Files` into empty and non-empty, returning `allEmpty` when no non-empty file exists.
  - `toS3Files()` now takes an explicit list and no longer mutates `this.s3Files` during sort.
- `tests/medium/s3-concat.test.ts`
  - New tests: `NotFoundFileWithoutMinSize` (reproduces the original issue), `AllEmpty`, `MixedWithEmpty`.
  - Updated existing `concatenated` expectations to include `skippedEmptyKeys: []`.

