### PR TITLE
feat: stream UploadPart bodies with CRC32 trailer (issue 004)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,58 @@ const s3Concat = new S3Concat({
 ```
 
 
+## Performance Tuning
+
+### `pLimit`
+
+`pLimit` is the total in-flight S3 I/O budget shared across every output
+file (one global semaphore). It caps the combined count of in-flight
+`UploadPart`, `UploadPartCopy`, and `GetObject` calls. The default is `5`.
+
+Increase it for high-throughput workloads (many parts per output, fast
+network); keep it low on memory-constrained runtimes such as small Lambda
+functions, where each in-flight upload part also pins ~64 KiB of stream
+buffer in memory.
+
+### Socket pool (`maxSockets`)
+
+> **Required when `pLimit ≥ 10`.** Each active part holds one `GetObject`
+> and one `UploadPart` socket concurrently. If `maxSockets ≤ pLimit`,
+> `UploadPart` requests queue inside the SDK and Smithy eventually aborts
+> them with a non-retryable streaming error that surfaces as
+> `AbortError: This operation was aborted`.
+
+`s3-concat` does not construct an `S3Client` for you, so the HTTP socket
+pool is yours to size. The default `NodeHttpHandler` keeps `maxSockets`
+at the Node `http.Agent` default (`50`).
+
+Set `maxSockets ≥ pLimit × 2` (each part needs 2 sockets, plus headroom
+for `CreateMultipartUpload` / `CompleteMultipartUpload` traffic):
+
+```ts
+import { Agent as HttpsAgent } from 'node:https';
+import { NodeHttpHandler } from '@smithy/node-http-handler';
+import { S3Client } from '@aws-sdk/client-s3';
+
+const pLimit = 50;
+const s3Client = new S3Client({
+  requestHandler: new NodeHttpHandler({
+    httpsAgent: new HttpsAgent({
+      maxSockets: pLimit * 2,
+      keepAlive: true,
+    }),
+  }),
+});
+```
+
+### Memory characteristics
+
+`UploadPart` streams source bytes through a 64 KiB coalescing buffer
+instead of materializing each part as one Buffer. In-flight memory scales
+as `O(pLimit × 64 KiB)` rather than `O(pLimit × 5 MiB × parts_per_output)`,
+which keeps tens-of-thousands-of-small-files workloads inside a 1 GiB
+Lambda envelope.
+
 ## License
 
 This project is licensed under the MIT License.

--- a/lib/s3-concat.ts
+++ b/lib/s3-concat.ts
@@ -82,7 +82,8 @@ export type ConcatParams = {
     | BuiltinJoinOrderCompareFnSpecifier;
   /**
    * The maximum number of concurrent asynchronous I/O operations.
-   * This limits the number of parallel S3 operations to avoid overwhelming the system.
+   * This limits the total in-flight `UploadPart` / `UploadPartCopy` /
+   * `GetObject` calls across all output files (one shared semaphore).
    * @default 5
    */
   pLimit?: number;
@@ -232,25 +233,27 @@ export class S3Concat {
       size: splitFile.s3Files.size,
     }));
 
+    // One shared semaphore caps the total in-flight S3 I/O across every
+    // output file. This replaces the v1.x "outer pLimit × inner pLimit"
+    // design, which let the effective concurrency reach pLimit² and made
+    // memory pressure scale with output count instead of just `pLimit`.
     const limit = pLimit(this.limitConcurrency);
 
     const keys = await Promise.all(
-      splitFileAndUploadTask.map((task) =>
-        limit(async () => {
-          const key = `${this.dstKey}/${task.keyName}`;
-          await s3Client.concatWithMultipartUpload(
-            this.s3Client,
-            this.dstBucketName,
-            key,
-            task.uploadTasks,
-            this.limitConcurrency
-          );
-          return {
-            key,
-            size: task.size,
-          };
-        })
-      )
+      splitFileAndUploadTask.map(async (task) => {
+        const key = `${this.dstKey}/${task.keyName}`;
+        await s3Client.concatWithMultipartUpload(
+          this.s3Client,
+          this.dstBucketName,
+          key,
+          task.uploadTasks,
+          limit
+        );
+        return {
+          key,
+          size: task.size,
+        };
+      })
     );
 
     return {

--- a/lib/s3/client.ts
+++ b/lib/s3/client.ts
@@ -1,15 +1,17 @@
 import {
+  AbortMultipartUploadCommand,
+  type ChecksumAlgorithm,
+  type CompletedPart,
   CompleteMultipartUploadCommand,
   CreateMultipartUploadCommand,
-  GetObjectCommand,
   ListObjectsV2Command,
   type ListObjectsV2CommandOutput,
   UploadPartCommand,
   UploadPartCopyCommand,
 } from '@aws-sdk/client-s3';
 import type { S3Client } from '../s3-concat';
-import pLimit from '../std/concurrency';
-import type { S3File } from './file';
+import type { LimitFunction } from '../std/concurrency';
+import { buildMergedBody } from './stream-body';
 import { getPartSizeForPartTask, type UploadTask } from './task';
 
 type S3FileInfo = { key: string; size: number; lastModified: Date };
@@ -65,56 +67,23 @@ export const getListFiles = async (
 const encodeCopySourceKey = (key: string): string =>
   key.split('/').map(encodeURIComponent).join('/');
 
-// Collect all source-file bytes for one PartTask into a single Buffer.
-//
-// UploadPartCommand selects its wire encoding based on the Body type:
-// a Buffer payload is sent with a known Content-Length (single-chunk
-// SigV4), while a Readable triggers aws-chunked streaming, which S3
-// gates on a 8192-byte minimum per non-final chunk. Streaming would
-// make us depend on the consumer's @aws-sdk/client-s3 version (3.97x+
-// stopped buffering input streams internally, so small GetObject body
-// chunks reach the wire intact and S3 rejects them). Collecting into
-// a Buffer sidesteps the chunked path entirely.
-//
-// Memory cost is bounded by S3 itself: planedUploadTask caps each
-// PartTask at PART_UPLOAD_LIMIT (5 MiB), so even with a saturated
-// pLimit the in-flight peak is roughly partSize * concurrency.
-const collectPartBytes = async (
-  s3Client: S3Client,
-  s3Files: S3File[],
-  bucketName: string
-): Promise<Buffer> => {
-  const parts: Buffer[] = [];
-  for (const f of s3Files) {
-    const range = `bytes=${f.start}-${f.size - 1}`;
-    const getRes = await s3Client.send(
-      new GetObjectCommand({
-        Bucket: bucketName,
-        Key: f.key,
-        Range: range,
-      })
-    );
-    const body = getRes.Body;
-    if (body === undefined) {
-      throw new Error(`empty body for s3://${bucketName}/${f.key}`);
-    }
-    const bytes = await body.transformToByteArray();
-    parts.push(Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength));
-  }
-  return Buffer.concat(parts);
-};
+// CRC32 keeps the streaming path on STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER
+// so the SDK never falls back to single-chunk SigV4, which would re-buffer the
+// whole part in memory and re-introduce the hazard streaming is meant to avoid.
+const STREAMING_CHECKSUM_ALGORITHM = 'CRC32' satisfies ChecksumAlgorithm;
 
 export const concatWithMultipartUpload = async (
   s3Client: S3Client,
   bucketName: string,
   newKey: string,
   tasks: UploadTask[],
-  limitNumber: number
+  limit: LimitFunction
 ): Promise<void> => {
   const createRes = await s3Client.send(
     new CreateMultipartUploadCommand({
       Bucket: bucketName,
       Key: newKey,
+      ChecksumAlgorithm: STREAMING_CHECKSUM_ALGORITHM,
     })
   );
   const uploadId = createRes.UploadId;
@@ -122,78 +91,105 @@ export const concatWithMultipartUpload = async (
     throw new Error('request failed CreateMultipartUploadCommand');
   }
 
-  const completedParts: Array<
-    { ETag?: string; PartNumber: number } | undefined
-  > = new Array(tasks.length);
+  const completedParts: Array<CompletedPart | undefined> = new Array(
+    tasks.length
+  );
 
-  const limit = pLimit(limitNumber);
+  try {
+    await Promise.all(
+      tasks.map((task, i) =>
+        limit(async () => {
+          const partNumber = i + 1;
 
-  await Promise.all(
-    tasks.map((task, i) =>
-      limit(async () => {
-        const partNumber = i + 1;
+          if (task.uploadType === 'PartCopy') {
+            const copySource = `${bucketName}/${encodeCopySourceKey(task.s3File.key)}`;
+            const copyRange = `bytes=${task.start}-${task.end - 1}`;
+            const copyRes = await s3Client.send(
+              new UploadPartCopyCommand({
+                Bucket: bucketName,
+                Key: newKey,
+                UploadId: uploadId,
+                PartNumber: partNumber,
+                CopySource: copySource,
+                CopySourceRange: copyRange,
+              })
+            );
 
-        if (task.uploadType === 'PartCopy') {
-          const copySource = `${bucketName}/${encodeCopySourceKey(task.s3File.key)}`;
-          const copyRange = `bytes=${task.start}-${task.end - 1}`;
-          const copyRes = await s3Client.send(
-            new UploadPartCopyCommand({
-              Bucket: bucketName,
-              Key: newKey,
-              UploadId: uploadId,
+            completedParts[i] = {
+              ETag: copyRes.CopyPartResult?.ETag,
               PartNumber: partNumber,
-              CopySource: copySource,
-              CopySourceRange: copyRange,
-            })
-          );
+              ChecksumCRC32: copyRes.CopyPartResult?.ChecksumCRC32,
+            };
+            return;
+          }
 
-          completedParts[i] = {
-            ETag: copyRes.CopyPartResult?.ETag,
-            PartNumber: partNumber,
-          };
-          return;
-        }
+          const partSize = getPartSizeForPartTask(task);
+          if (partSize === 0) {
+            return;
+          }
 
-        const partSize = getPartSizeForPartTask(task);
-        if (partSize === 0) {
-          return;
-        }
+          const controller = new AbortController();
+          const merged = buildMergedBody({
+            s3Client,
+            bucketName,
+            s3Files: task.s3Files,
+            signal: controller.signal,
+            contentLength: partSize,
+          });
+          try {
+            const uploadRes = await s3Client.send(
+              new UploadPartCommand({
+                Bucket: bucketName,
+                Key: newKey,
+                UploadId: uploadId,
+                PartNumber: partNumber,
+                Body: merged.stream,
+                ContentLength: merged.contentLength,
+                ChecksumAlgorithm: STREAMING_CHECKSUM_ALGORITHM,
+              })
+            );
+            completedParts[i] = {
+              ETag: uploadRes.ETag,
+              PartNumber: partNumber,
+              ChecksumCRC32: uploadRes.ChecksumCRC32,
+            };
+          } catch (err) {
+            controller.abort();
+            // The SDK surfaces a generic AbortError when we destroy the body
+            // stream from buildMergedBody (e.g. on a GetObject failure). Pull
+            // the original cause back out so SlowDown / 503 / socket timeout
+            // / checksum mismatch survives instead of being masked.
+            const upstream = merged.firstError();
+            throw upstream ?? err;
+          }
+        })
+      )
+    );
 
-        const partBytes = await collectPartBytes(
-          s3Client,
-          task.s3Files,
-          bucketName
-        );
-
-        const uploadRes = await s3Client.send(
-          new UploadPartCommand({
-            Bucket: bucketName,
-            Key: newKey,
-            UploadId: uploadId,
-            PartNumber: partNumber,
-            Body: partBytes,
-            ContentLength: partBytes.length,
-          })
-        );
-
-        completedParts[i] = {
-          ETag: uploadRes.ETag,
-          PartNumber: partNumber,
-        };
+    await s3Client.send(
+      new CompleteMultipartUploadCommand({
+        Bucket: bucketName,
+        Key: newKey,
+        UploadId: uploadId,
+        MultipartUpload: {
+          Parts: completedParts.filter(
+            (p): p is CompletedPart => p !== undefined
+          ),
+        },
       })
-    )
-  );
-
-  await s3Client.send(
-    new CompleteMultipartUploadCommand({
-      Bucket: bucketName,
-      Key: newKey,
-      UploadId: uploadId,
-      MultipartUpload: {
-        Parts: completedParts.filter(
-          (p): p is { ETag?: string; PartNumber: number } => p !== undefined
-        ),
-      },
-    })
-  );
+    );
+  } catch (err) {
+    try {
+      await s3Client.send(
+        new AbortMultipartUploadCommand({
+          Bucket: bucketName,
+          Key: newKey,
+          UploadId: uploadId,
+        })
+      );
+    } catch {
+      // Best-effort cleanup; surface the original error.
+    }
+    throw err;
+  }
 };

--- a/lib/s3/coalesce-transform.ts
+++ b/lib/s3/coalesce-transform.ts
@@ -1,0 +1,39 @@
+import { Transform, type TransformCallback } from 'node:stream';
+
+// S3 aws-chunked encoding rejects non-final chunks smaller than 8 KiB.
+// 64 KiB matches the AWS SDK's default requestStreamBufferSize and gives
+// enough headroom that GetObject's ~16 KiB IncomingMessage chunks always
+// land above the threshold after one or two coalesce passes.
+export const COALESCE_MIN = 64 * 1024;
+
+export class CoalesceTransform extends Transform {
+  private pending: Buffer[] = [];
+  private pendingSize = 0;
+
+  _transform(
+    chunk: Buffer,
+    _encoding: BufferEncoding,
+    callback: TransformCallback
+  ): void {
+    this.pending.push(chunk);
+    this.pendingSize += chunk.byteLength;
+
+    if (this.pendingSize >= COALESCE_MIN) {
+      const merged = Buffer.concat(this.pending, this.pendingSize);
+      this.pending = [];
+      this.pendingSize = 0;
+      this.push(merged);
+    }
+    callback();
+  }
+
+  _flush(callback: TransformCallback): void {
+    if (this.pendingSize > 0) {
+      const merged = Buffer.concat(this.pending, this.pendingSize);
+      this.pending = [];
+      this.pendingSize = 0;
+      this.push(merged);
+    }
+    callback();
+  }
+}

--- a/lib/s3/stream-body.ts
+++ b/lib/s3/stream-body.ts
@@ -1,0 +1,119 @@
+import type { Readable } from 'node:stream';
+import { GetObjectCommand } from '@aws-sdk/client-s3';
+import type { S3Client } from '../s3-concat';
+import { CoalesceTransform } from './coalesce-transform';
+import type { S3File } from './file';
+
+export interface BuildMergedBodyOptions {
+  s3Client: S3Client;
+  bucketName: string;
+  s3Files: S3File[];
+  signal: AbortSignal;
+  contentLength: number;
+}
+
+export interface MergedBody {
+  stream: Readable;
+  contentLength: number;
+  /**
+   * Returns the first error captured while pulling source bytes (e.g. a
+   * `GetObject` SlowDown or socket timeout). Use it to recover the real
+   * cause when `UploadPart` rejects with the SDK's generic AbortError —
+   * destroying the body stream makes the SDK surface "aborted" instead
+   * of the upstream failure.
+   */
+  firstError: () => Error | undefined;
+}
+
+const writeChunkWithBackpressure = (
+  coalesce: CoalesceTransform,
+  body: Readable
+): Promise<void> =>
+  new Promise<void>((resolve, reject) => {
+    const onData = (chunk: Buffer): void => {
+      if (!coalesce.write(chunk)) {
+        body.pause();
+        coalesce.once('drain', () => {
+          body.resume();
+        });
+      }
+    };
+    const onEnd = (): void => {
+      cleanup();
+      resolve();
+    };
+    const onError = (err: Error): void => {
+      cleanup();
+      reject(err);
+    };
+    const cleanup = (): void => {
+      body.off('data', onData);
+      body.off('end', onEnd);
+      body.off('error', onError);
+    };
+    body.on('data', onData);
+    body.on('end', onEnd);
+    body.on('error', onError);
+  });
+
+export const buildMergedBody = (opts: BuildMergedBodyOptions): MergedBody => {
+  const coalesce = new CoalesceTransform();
+  let activeBody: Readable | undefined;
+  let firstError: Error | undefined;
+
+  const capture = (err: Error): void => {
+    if (firstError === undefined) firstError = err;
+  };
+
+  const abortListener = (): void => {
+    const reason = (opts.signal as AbortSignal & { reason?: unknown }).reason;
+    const err = reason instanceof Error ? reason : new Error('aborted');
+    capture(err);
+    activeBody?.destroy(err);
+    coalesce.destroy(err);
+  };
+  opts.signal.addEventListener('abort', abortListener, { once: true });
+
+  const run = async (): Promise<void> => {
+    for (const f of opts.s3Files) {
+      if (opts.signal.aborted) {
+        throw new Error('aborted');
+      }
+      const range = `bytes=${f.start}-${f.size - 1}`;
+      const getRes = await opts.s3Client.send(
+        new GetObjectCommand({
+          Bucket: opts.bucketName,
+          Key: f.key,
+          Range: range,
+        })
+      );
+      const body = getRes.Body as Readable | undefined;
+      if (body === undefined) {
+        throw new Error(`empty body for s3://${opts.bucketName}/${f.key}`);
+      }
+      activeBody = body;
+      try {
+        await writeChunkWithBackpressure(coalesce, body);
+      } finally {
+        activeBody = undefined;
+      }
+    }
+    coalesce.end();
+  };
+
+  run()
+    .catch((err: unknown) => {
+      const error = err instanceof Error ? err : new Error(String(err));
+      capture(error);
+      coalesce.destroy(error);
+    })
+    .finally(() => {
+      opts.signal.removeEventListener('abort', abortListener);
+    });
+
+  return {
+    stream: coalesce,
+    contentLength: opts.contentLength,
+    firstError: () => firstError,
+  };
+};

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "check:spell": "cspell lint . --cache --gitignore",
     "clean": "rimraf dist",
     "test": "vitest run --config vitest.config.ts --coverage.enabled true --reporter=verbose",
+    "test:unit": "vitest run --config vitest.unit.config.ts --reporter=verbose",
     "test:sdk-matrix": "bash scripts/sdk-matrix.sh test",
     "e2e": "USE_REAL_S3=1 vitest run --config vitest.config.ts --reporter=verbose",
     "e2e:sdk-matrix": "bash scripts/sdk-matrix.sh e2e",

--- a/tests/unit/s3/coalesce-transform.test.ts
+++ b/tests/unit/s3/coalesce-transform.test.ts
@@ -1,0 +1,112 @@
+import type { Readable } from 'node:stream';
+import { describe, expect, test } from 'vitest';
+import {
+  COALESCE_MIN,
+  CoalesceTransform,
+} from '../../../lib/s3/coalesce-transform';
+
+const drain = (stream: Readable): Promise<Buffer[]> =>
+  new Promise<Buffer[]>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    stream.on('data', (c: Buffer) => chunks.push(c));
+    stream.on('end', () => resolve(chunks));
+    stream.on('error', reject);
+  });
+
+const writeAll = (
+  coalesce: CoalesceTransform,
+  inputs: Buffer[]
+): Promise<void> =>
+  new Promise<void>((resolve, reject) => {
+    let i = 0;
+    const next = (): void => {
+      while (i < inputs.length) {
+        const ok = coalesce.write(inputs[i] as Buffer);
+        i += 1;
+        if (!ok) {
+          coalesce.once('drain', next);
+          return;
+        }
+      }
+      coalesce.end();
+      resolve();
+    };
+    coalesce.on('error', reject);
+    next();
+  });
+
+describe('CoalesceTransform', () => {
+  test('coalesces sub-threshold chunks until threshold is reached', async () => {
+    const coalesce = new CoalesceTransform();
+    const drained = drain(coalesce);
+
+    // 4 KiB × 16 = 64 KiB exactly hits the threshold.
+    const small = Buffer.alloc(4 * 1024, 0x41);
+    await writeAll(
+      coalesce,
+      Array.from({ length: 16 }, () => small)
+    );
+
+    const chunks = await drained;
+    expect(chunks.length).toBe(1);
+    expect((chunks[0] as Buffer).byteLength).toBe(COALESCE_MIN);
+  });
+
+  test('passes a single large chunk through immediately', async () => {
+    const coalesce = new CoalesceTransform();
+    const drained = drain(coalesce);
+
+    const big = Buffer.alloc(COALESCE_MIN * 2 + 17, 0x42);
+    await writeAll(coalesce, [big]);
+
+    const chunks = await drained;
+    expect(chunks.length).toBe(1);
+    expect((chunks[0] as Buffer).byteLength).toBe(big.byteLength);
+  });
+
+  test('emits remaining bytes from _flush even if smaller than threshold', async () => {
+    const coalesce = new CoalesceTransform();
+    const drained = drain(coalesce);
+
+    const tail = Buffer.from('trailing-bytes');
+    await writeAll(coalesce, [tail]);
+
+    const chunks = await drained;
+    expect(chunks.length).toBe(1);
+    expect((chunks[0] as Buffer).toString()).toBe('trailing-bytes');
+  });
+
+  test('chains multiple coalesced chunks while crossing threshold repeatedly', async () => {
+    const coalesce = new CoalesceTransform();
+    const drained = drain(coalesce);
+
+    const block = Buffer.alloc(40 * 1024, 0x43); // 40 KiB
+    // 40 KiB ×5 = 200 KiB → coalesces fire at the >=64 KiB boundary on
+    // every other write (40 → 80 → 120 → 160 → 200). With current _transform
+    // logic that yields three pushes plus a final flushed remainder.
+    await writeAll(
+      coalesce,
+      Array.from({ length: 5 }, () => block)
+    );
+
+    const chunks = await drained;
+    const totalBytes = chunks.reduce((sum, c) => sum + c.byteLength, 0);
+    expect(totalBytes).toBe(block.byteLength * 5);
+    for (const c of chunks.slice(0, -1)) {
+      expect(c.byteLength).toBeGreaterThanOrEqual(COALESCE_MIN);
+    }
+  });
+
+  test('propagates upstream errors via destroy', async () => {
+    const coalesce = new CoalesceTransform();
+    const err = new Error('boom');
+
+    const failed: Promise<Error> = new Promise((resolve) => {
+      coalesce.on('error', (e: Error) => resolve(e));
+    });
+
+    coalesce.destroy(err);
+
+    expect(await failed).toBe(err);
+  });
+});

--- a/tests/unit/s3/stream-body.test.ts
+++ b/tests/unit/s3/stream-body.test.ts
@@ -1,0 +1,137 @@
+import { Readable } from 'node:stream';
+import { describe, expect, test, vi } from 'vitest';
+import { S3File } from '../../../lib/s3/file';
+import { buildMergedBody } from '../../../lib/s3/stream-body';
+
+type SendCall = (command: unknown) => Promise<unknown>;
+
+const drain = (stream: Readable): Promise<Buffer> =>
+  new Promise<Buffer>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    stream.on('data', (c: Buffer) => chunks.push(c));
+    stream.on('end', () => resolve(Buffer.concat(chunks)));
+    stream.on('error', reject);
+  });
+
+const makeBody = (payload: Buffer | Buffer[]): Readable => {
+  const arr = Array.isArray(payload) ? payload : [payload];
+  return Readable.from(arr);
+};
+
+describe('buildMergedBody', () => {
+  test('concatenates multiple GetObject bodies in order', async () => {
+    const files = [
+      new S3File('a.txt', 5, 0),
+      new S3File('b.txt', 4, 0),
+      new S3File('c.txt', 3, 0),
+    ];
+    const payloads: Record<string, Buffer> = {
+      'a.txt': Buffer.from('AAAAA'),
+      'b.txt': Buffer.from('BBBB'),
+      'c.txt': Buffer.from('CCC'),
+    };
+
+    const send = vi.fn<SendCall>(async (command) => {
+      const key = (command as { input: { Key: string } }).input.Key;
+      return { Body: makeBody(payloads[key] as Buffer) };
+    });
+
+    const controller = new AbortController();
+    const merged = buildMergedBody({
+      s3Client: { send },
+      bucketName: 'b',
+      s3Files: files,
+      signal: controller.signal,
+      contentLength: 12,
+    });
+
+    const result = await drain(merged.stream);
+    expect(result.toString()).toBe(`${'AAAAA'}${'BBBB'}${'CCC'}`);
+    expect(merged.contentLength).toBe(12);
+    expect(send).toHaveBeenCalledTimes(3);
+  });
+
+  test('propagates GetObject errors as a stream error', async () => {
+    const files = [new S3File('a.txt', 4, 0)];
+    const send = vi.fn<SendCall>(async () => {
+      throw new Error('get-object failure');
+    });
+
+    const merged = buildMergedBody({
+      s3Client: { send },
+      bucketName: 'b',
+      s3Files: files,
+      signal: new AbortController().signal,
+      contentLength: 4,
+    });
+
+    await expect(drain(merged.stream)).rejects.toThrow('get-object failure');
+  });
+
+  test('exposes the upstream cause via firstError()', async () => {
+    const files = [new S3File('a.txt', 4, 0)];
+    const cause = new Error('SlowDown');
+    const send = vi.fn<SendCall>(async () => {
+      throw cause;
+    });
+
+    const merged = buildMergedBody({
+      s3Client: { send },
+      bucketName: 'b',
+      s3Files: files,
+      signal: new AbortController().signal,
+      contentLength: 4,
+    });
+
+    await expect(drain(merged.stream)).rejects.toBeDefined();
+    expect(merged.firstError()).toBe(cause);
+  });
+
+  test('throws "empty body" when GetObject returns no Body', async () => {
+    const files = [new S3File('a.txt', 1, 0)];
+    const send = vi.fn<SendCall>(async () => ({ Body: undefined }));
+
+    const merged = buildMergedBody({
+      s3Client: { send },
+      bucketName: 'b',
+      s3Files: files,
+      signal: new AbortController().signal,
+      contentLength: 1,
+    });
+
+    await expect(drain(merged.stream)).rejects.toThrow(/empty body/);
+  });
+
+  test('aborting during an in-flight GetObject prevents further requests', async () => {
+    const files = [
+      new S3File('a.txt', 3, 0),
+      new S3File('b.txt', 3, 0),
+      new S3File('c.txt', 3, 0),
+    ];
+
+    // The first send hangs forever so the loop never advances on its own,
+    // letting us observe that abort stops it before file b/c are requested.
+    const send = vi.fn<SendCall>(() => new Promise<never>(() => undefined));
+
+    const controller = new AbortController();
+    const merged = buildMergedBody({
+      s3Client: { send },
+      bucketName: 'b',
+      s3Files: files,
+      signal: controller.signal,
+      contentLength: 9,
+    });
+
+    const drained = drain(merged.stream);
+
+    await vi.waitFor(() => {
+      expect(send).toHaveBeenCalledTimes(1);
+    });
+
+    controller.abort(new Error('cancelled'));
+
+    await expect(drained).rejects.toThrow('cancelled');
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(send.mock.calls.length).toBe(1);
+  });
+});

--- a/vitest.unit.config.ts
+++ b/vitest.unit.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'unit',
+    dir: 'tests/unit',
+    globals: true,
+    testTimeout: 10_000,
+  },
+});


### PR DESCRIPTION
## Summary

- Replace `UploadPart`'s `Buffer.concat` strategy with a streaming pipeline that coalesces `GetObject` chunks through a 64 KiB Transform and forwards CRC32 checksums via aws-chunked TRAILER. Per-part in-flight memory drops from ~5 MiB to ~64 KiB.
- Collapse the outer × inner `pLimit` (which let effective concurrency hit N²) into a single shared semaphore. `pLimit` is now the global I/O budget across every output file.
- README updated: when `pLimit ≥ 10`, `maxSockets ≥ pLimit × 2` is now required (each in-flight part holds one `GetObject` + one `UploadPart` socket).

Fixes the memory and HTTP socket pressure described in issue where 50,000 × 100 KiB files in a 10 GiB Lambda put RSS at 8.9 GiB and stalled on socket exhaustion.

## Measurement

Lambda extreme profile (50,000 × 100 KiB, `pLimit=50`, `minSize=100 MiB`, `maxSockets=200`) measured against v1.4.0:

| Metric | v1.4.0 | This PR | Δ |
|---|---|---|---|
| arrayBuffers peak | 4,885 MB | 41.5 MB | -99% |
| Max Memory Used | 8,693 MB | 429 MB | -95% |
| Duration | 172.0 s | 119.4 s | -30% |

`pLimitBomb` profile (manySmall data, `pLimit=50`):

| Metric | v1.4.0 | This PR |
|---|---|---|
| Max Memory | 1,358 MB | 310 MB |
| arrayBuffers | 369 MB | 36.8 MB |

Output structure unchanged (49 × 100 MiB files), no socket warnings emitted.

## API compatibility

- No `ConcatParams` change; existing callers run unmodified.
- `peerDependencies` range unchanged (`@aws-sdk/client-s3 >=3.300.0 <4.0.0`).
- Behavior change: `pLimit` is now the **global** in-flight cap instead of per-output. Existing `pLimit=5` callers see lower peak concurrency (5, not 5×output_count). Document in CHANGELOG.

## Implementation

- `lib/s3/coalesce-transform.ts`: 64 KiB coalescing `Transform`. Avoids the S3 ≥ 8 KiB chunk constraint on the aws-chunked path independent of the consumer SDK's internal buffering behavior.
- `lib/s3/stream-body.ts`: sequential `GetObject` → single `Readable` with `AbortController`-based cancellation. Exposes `firstError()` so `UploadPart`'s `catch` can re-throw the upstream cause instead of the SDK's generic `AbortError`.
- `lib/s3/client.ts`: streaming `UploadPart` with `ChecksumAlgorithm: 'CRC32'`, `AbortMultipartUpload` cleanup on any task failure.
- `lib/s3-concat.ts`: single shared `pLimit` semaphore passed to `concatWithMultipartUpload`.

## Test plan

- [x] `pnpm test:unit` — 10/10 (CoalesceTransform, buildMergedBody, including `firstError()` and abort tests)
- [x] `pnpm test` (floci medium tests) — 30/30
- [x] `pnpm e2e:sdk-matrix` (real S3, ap-northeast-1) — **270/270 passing across @aws-sdk/client-s3 3.300.0 → latest (9 versions)**
- [x] `pnpm check` (tsc / biome lint / biome format / cspell) — all green
- [x] Lambda extreme + pLimitBomb e2e — numbers above

## Follow-ups

- Defensive warn when `S3Client.config.requestHandler`'s `maxSockets` is below `pLimit × 2`. Tracked as a future PR; current PR ships the documented contract.