### PR TITLE
fix: cross-bucket concat and broken types path in 1.5.0

### DIFF
--- a/lib/s3-concat.ts
+++ b/lib/s3-concat.ts
@@ -244,6 +244,7 @@ export class S3Concat {
         const key = `${this.dstKey}/${task.keyName}`;
         await s3Client.concatWithMultipartUpload(
           this.s3Client,
+          this.srcBucketName,
           this.dstBucketName,
           key,
           task.uploadTasks,

--- a/lib/s3/client.ts
+++ b/lib/s3/client.ts
@@ -74,14 +74,15 @@ const STREAMING_CHECKSUM_ALGORITHM = 'CRC32' satisfies ChecksumAlgorithm;
 
 export const concatWithMultipartUpload = async (
   s3Client: S3Client,
-  bucketName: string,
+  srcBucketName: string,
+  dstBucketName: string,
   newKey: string,
   tasks: UploadTask[],
   limit: LimitFunction
 ): Promise<void> => {
   const createRes = await s3Client.send(
     new CreateMultipartUploadCommand({
-      Bucket: bucketName,
+      Bucket: dstBucketName,
       Key: newKey,
       ChecksumAlgorithm: STREAMING_CHECKSUM_ALGORITHM,
     })
@@ -102,11 +103,11 @@ export const concatWithMultipartUpload = async (
           const partNumber = i + 1;
 
           if (task.uploadType === 'PartCopy') {
-            const copySource = `${bucketName}/${encodeCopySourceKey(task.s3File.key)}`;
+            const copySource = `${srcBucketName}/${encodeCopySourceKey(task.s3File.key)}`;
             const copyRange = `bytes=${task.start}-${task.end - 1}`;
             const copyRes = await s3Client.send(
               new UploadPartCopyCommand({
-                Bucket: bucketName,
+                Bucket: dstBucketName,
                 Key: newKey,
                 UploadId: uploadId,
                 PartNumber: partNumber,
@@ -131,7 +132,7 @@ export const concatWithMultipartUpload = async (
           const controller = new AbortController();
           const merged = buildMergedBody({
             s3Client,
-            bucketName,
+            srcBucketName,
             s3Files: task.s3Files,
             signal: controller.signal,
             contentLength: partSize,
@@ -139,7 +140,7 @@ export const concatWithMultipartUpload = async (
           try {
             const uploadRes = await s3Client.send(
               new UploadPartCommand({
-                Bucket: bucketName,
+                Bucket: dstBucketName,
                 Key: newKey,
                 UploadId: uploadId,
                 PartNumber: partNumber,
@@ -168,7 +169,7 @@ export const concatWithMultipartUpload = async (
 
     await s3Client.send(
       new CompleteMultipartUploadCommand({
-        Bucket: bucketName,
+        Bucket: dstBucketName,
         Key: newKey,
         UploadId: uploadId,
         MultipartUpload: {
@@ -182,7 +183,7 @@ export const concatWithMultipartUpload = async (
     try {
       await s3Client.send(
         new AbortMultipartUploadCommand({
-          Bucket: bucketName,
+          Bucket: dstBucketName,
           Key: newKey,
           UploadId: uploadId,
         })

--- a/lib/s3/stream-body.ts
+++ b/lib/s3/stream-body.ts
@@ -6,7 +6,7 @@ import type { S3File } from './file';
 
 export interface BuildMergedBodyOptions {
   s3Client: S3Client;
-  bucketName: string;
+  srcBucketName: string;
   s3Files: S3File[];
   signal: AbortSignal;
   contentLength: number;
@@ -82,14 +82,14 @@ export const buildMergedBody = (opts: BuildMergedBodyOptions): MergedBody => {
       const range = `bytes=${f.start}-${f.size - 1}`;
       const getRes = await opts.s3Client.send(
         new GetObjectCommand({
-          Bucket: opts.bucketName,
+          Bucket: opts.srcBucketName,
           Key: f.key,
           Range: range,
         })
       );
       const body = getRes.Body as Readable | undefined;
       if (body === undefined) {
-        throw new Error(`empty body for s3://${opts.bucketName}/${f.key}`);
+        throw new Error(`empty body for s3://${opts.srcBucketName}/${f.key}`);
       }
       activeBody = body;
       try {

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "Concatenate multiple files in AWS S3 using multipart upload.",
   "type": "module",
   "main": "dist/s3-concat.umd.cjs",
-  "types": "dist/s3-concat.d.ts",
+  "types": "dist/lib/s3-concat.d.ts",
   "module": "dist/s3-concat.js",
   "exports": {
     ".": {
-      "types": "./dist/s3-concat.d.ts",
+      "types": "./dist/lib/s3-concat.d.ts",
       "import": "./dist/s3-concat.js",
       "require": "./dist/s3-concat.umd.cjs"
     }

--- a/tests/helpers/s3-helper.ts
+++ b/tests/helpers/s3-helper.ts
@@ -59,6 +59,13 @@ export class S3ClientHelper {
     };
   }
 
+  async createEmptyBucket(): Promise<{ bucketName: string }> {
+    const bucketName = `bucket-${randomUUID()}`;
+    await this.s3Client.send(new CreateBucketCommand({ Bucket: bucketName }));
+    onTestFinished(() => this.cleanupBucket(bucketName));
+    return { bucketName };
+  }
+
   uploadFile(bucketName: string, key: string, body: Buffer) {
     return this.s3Client.send(
       new PutObjectCommand({

--- a/tests/medium/s3-concat.test.ts
+++ b/tests/medium/s3-concat.test.ts
@@ -448,6 +448,81 @@ describe('concat', () => {
     }
   });
 
+  test('CrossBucketConcat', async () => {
+    // Given: files in a src bucket, an empty dst bucket. The mix of <5 MiB
+    // and >=5 MiB inputs exercises both the streaming GetObject path and the
+    // UploadPartCopy path — both used to read from dst instead of src.
+    const files = [
+      {
+        fileSize: 1000 * KiB,
+        fileCount: 11,
+      },
+      {
+        fileSize: 5 * MiB,
+        fileCount: 3,
+      },
+    ];
+    const prefix = 'tmp';
+    const dstPrefix = 'output';
+    const concatFileName = 'output.json';
+    const s3Client = createTestS3Client(TEST_S3_CONFIG);
+    const s3ClientHelper = new S3ClientHelper(s3Client);
+    const { bucketName: srcBucketName } = await s3ClientHelper.setupS3({
+      files,
+      prefix,
+    });
+    const { bucketName: dstBucketName } =
+      await s3ClientHelper.createEmptyBucket();
+
+    const s3Concat = new S3Concat({
+      s3Client,
+      srcBucketName,
+      dstBucketName,
+      dstPrefix,
+      concatFileName,
+    });
+    await s3Concat.addFiles(prefix);
+
+    // When:
+    const result = await s3Concat.concat();
+
+    // Then: concatenated object lands in the dst bucket.
+    expect(result).toEqual({
+      keys: [
+        {
+          key: `${dstPrefix}/${concatFileName}`,
+          size: 1000 * KiB * 11 + 5 * MiB * 3,
+        },
+      ],
+      kind: 'concatenated',
+      skippedEmptyKeys: [],
+    });
+    const dstListing = await s3Client.send(
+      new ListObjectsV2Command({
+        Bucket: dstBucketName,
+        Prefix: dstPrefix,
+      })
+    );
+    expect(dstListing.Contents).toEqual([
+      expect.objectContaining({
+        ETag: expect.any(String),
+        Key: `${dstPrefix}/${concatFileName}`,
+        LastModified: expect.any(Date),
+        Size: 1000 * KiB * 11 + 5 * MiB * 3,
+        StorageClass: 'STANDARD',
+      }),
+    ]);
+
+    // And: src bucket is untouched — no output/ prefix appeared on src.
+    const srcDstPrefixListing = await s3Client.send(
+      new ListObjectsV2Command({
+        Bucket: srcBucketName,
+        Prefix: dstPrefix,
+      })
+    );
+    expect(srcDstPrefixListing.Contents ?? []).toEqual([]);
+  });
+
   test('MixedWithEmpty', async () => {
     // Given:
     const prefix = 'tmp';

--- a/tests/unit/s3/stream-body.test.ts
+++ b/tests/unit/s3/stream-body.test.ts
@@ -39,7 +39,7 @@ describe('buildMergedBody', () => {
     const controller = new AbortController();
     const merged = buildMergedBody({
       s3Client: { send },
-      bucketName: 'b',
+      srcBucketName: 'b',
       s3Files: files,
       signal: controller.signal,
       contentLength: 12,
@@ -59,7 +59,7 @@ describe('buildMergedBody', () => {
 
     const merged = buildMergedBody({
       s3Client: { send },
-      bucketName: 'b',
+      srcBucketName: 'b',
       s3Files: files,
       signal: new AbortController().signal,
       contentLength: 4,
@@ -77,7 +77,7 @@ describe('buildMergedBody', () => {
 
     const merged = buildMergedBody({
       s3Client: { send },
-      bucketName: 'b',
+      srcBucketName: 'b',
       s3Files: files,
       signal: new AbortController().signal,
       contentLength: 4,
@@ -93,7 +93,7 @@ describe('buildMergedBody', () => {
 
     const merged = buildMergedBody({
       s3Client: { send },
-      bucketName: 'b',
+      srcBucketName: 'b',
       s3Files: files,
       signal: new AbortController().signal,
       contentLength: 1,
@@ -116,7 +116,7 @@ describe('buildMergedBody', () => {
     const controller = new AbortController();
     const merged = buildMergedBody({
       s3Client: { send },
-      bucketName: 'b',
+      srcBucketName: 'b',
       s3Files: files,
       signal: controller.signal,
       contentLength: 9,


### PR DESCRIPTION
## Summary

Two regressions shipped in the 1.5.0 release:

- **Cross-bucket concat fails with `NoSuchKey`.** When `srcBucketName !== dstBucketName`, the internal read ops were issued against the dst bucket and always failed.
- **Consumer-side type resolution is broken.** `package.json`'s `types` / `exports.types` point at a path that does not exist after build, so `tsc` reports `Could not find a declaration file for module 's3-concat'`.

Public `ConcatParams` (`srcBucketName` / `dstBucketName`) is unchanged — both fixes are transparent to callers.

## Commit 1: `fix: read parts from srcBucketName instead of dstBucketName`

### Root cause

When `concat()` was extracted into `lib/s3/client.ts::concatWithMultipartUpload` in #6, the call collapsed src/dst into a single `bucketName: string`, so the read ops accidentally targeted the dst bucket:

- `UploadPartCopyCommand.CopySource = ${bucketName}/${key}` — read from dst
- Streaming path's `buildMergedBody`: `GetObject.Bucket = bucketName` — read from dst

Existing tests all used the same bucket for both, so the regression slipped through.

### Changes

- `lib/s3/client.ts` — `concatWithMultipartUpload(s3Client, bucketName, ...)` becomes `(s3Client, srcBucketName, dstBucketName, ...)`. Read ops (`UploadPartCopy.CopySource`, `buildMergedBody` / `GetObject`) use src; write ops (`CreateMultipartUpload`, `UploadPart`, `CompleteMultipartUpload`, `AbortMultipartUpload`) use dst. Positional shape preserved.
- `lib/s3/stream-body.ts` — rename `BuildMergedBodyOptions.bucketName` to `srcBucketName` to make the intent obvious at the call site.
- `lib/s3-concat.ts` — pass `this.srcBucketName` through from `concat()`.
- `tests/helpers/s3-helper.ts` — add `createEmptyBucket()` for the cross-bucket test.
- `tests/medium/s3-concat.test.ts` — add `CrossBucketConcat` covering both the streaming (<5 MiB) and PartCopy (≥5 MiB) paths against separate src/dst buckets. Asserts the dst bucket receives the concatenated object and the src bucket is left untouched.
- `tests/unit/s3/stream-body.test.ts` — follow the field rename.

## Commit 2: `fix: point package types path to actual emitted d.ts`

### Root cause

`vite-plugin-dts` emits declarations under `dist/lib/`, but `package.json`'s `types` and `exports[".".types]` both pointed at `dist/s3-concat.d.ts` (which does not exist). Consumers running `tsc` fell back to no-types and saw `Could not find a declaration file for module 's3-concat'`. Broken since the 1.5.0 publish.

### Changes

- `package.json` — point `types` and `exports[".".types]` to `dist/lib/s3-concat.d.ts` (where `vite-plugin-dts` actually writes the entry declaration).

## Test plan

- [x] `pnpm test:unit` — 10/10 PASS
- [x] `pnpm test` (Floci) — 31/31 PASS (incl. new `CrossBucketConcat`, 1539ms)
- [x] `pnpm e2e` (real S3, ap-northeast-1) — 31/31 PASS (incl. `CrossBucketConcat`, 8585ms)
- [x] `pnpm run check:type`
- [x] Consumer-side smoke test (`verify-src-dst-buckets.ts`) — 4 real-S3 cases (streaming / PartCopy / mixed / minSize split) all OK in ap-northeast-1
- [x] After `pnpm run build`, `dist/lib/s3-concat.d.ts` exists
