### PR TITLE
chore: bound node engines range and widen on renovate

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "nodejs"
   ],
   "engines": {
-    "node": ">=22.22.3"
+    "node": ">=22.22.3 <25"
   },
   "release": {
     "branches": [

--- a/renovate.json
+++ b/renovate.json
@@ -33,6 +33,12 @@
       "description": "Group AWS SDK packages",
       "matchPackageNames": ["@aws-sdk/**"],
       "groupName": "aws-sdk"
+    },
+    {
+      "description": "Widen Node engines range instead of bumping the floor",
+      "matchDepNames": ["node"],
+      "matchManagers": ["npm"],
+      "rangeStrategy": "widen"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Cap the `engines.node` range at `<25` so the supported floor stays at Node 22 (current LTS) instead of being silently moved up every time a new Node major lands.
- Add a Renovate rule that uses `rangeStrategy: widen` for the `node` dep so future Node majors expand the upper bound rather than bumping the floor.
- Supersedes `renovate/node-24.x`, which would have replaced `>=22.22.3` with `>=24.16.0` and dropped Node 22 support unnecessarily.

## Changes

- `package.json`: `engines.node` `>=22.22.3` → `>=22.22.3 <25`.
- `renovate.json`: add a `packageRule` matching `depNames: [node]` under the `npm` manager with `rangeStrategy: widen`.
