### PR TITLE
feat: add S3Concat.executePlan static method for split plan/execute flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,38 @@ const s3Concat = new S3Concat({
 ```
 
 
+#### Example 5: Split plan and execute across steps (Durable Lambda / Step Functions)
+
+`plan()` returns a JSON-serializable snapshot. Persist it as a checkpoint, then replay it later with `S3Concat.executePlan(plan, …)` — no re-listing of the source bucket.
+
+```ts
+import { S3Client } from '@aws-sdk/client-s3';
+import { type Plan, S3Concat } from 's3-concat';
+
+const s3Client = new S3Client({});
+
+// Step A: build the plan and persist it as a Step Functions state, Durable Functions checkpoint, Slack approval payload, etc.
+const planStep = async (): Promise<Plan> => {
+  const s3c = new S3Concat({
+    s3Client,
+    srcBucketName: 'athena-unload-output',
+    dstBucketName: 'merged-bucket',
+    dstPrefix: 'merged',
+    concatFileName: 'result.jsonl',
+  });
+  await s3c.addFiles('unload/query-id-xxxx/');
+  const result = s3c.plan();
+  if (result.kind !== 'planned') throw new Error(`nothing to concat: ${result.kind}`);
+  return result;
+};
+
+// Step B: replay. Bucket names come from the plan (mutate to redirect).
+// `check: true` HeadObjects every source first; set it when the source may drift between plan() and executePlan().
+// Without it, a deleted or shrunk source < 5 MiB stalls the UploadPart on the SDK's stream timeout with an unhandled rejection; ≥ 5 MiB sources fail fast via UploadPartCopy.
+const executeStep = (plan: Plan) =>
+  S3Concat.executePlan(plan, { s3Client, check: true });
+```
+
 ## Performance Tuning
 
 ### `pLimit`

--- a/lib/cli/main.ts
+++ b/lib/cli/main.ts
@@ -114,8 +114,12 @@ export const run = async (options: RunOptions): Promise<number> => {
               if (src === undefined) continue;
               const isLastSrc = j === part.sources.length - 1;
               const srcBranch = isLastSrc ? '└─' : '├─';
+              const rangeSuffix =
+                src.rangeStart > 0
+                  ? ` bytes=${src.rangeStart}-${src.rangeStart + src.bytes - 1}`
+                  : '';
               stdio.stdout.write(
-                `${sourceIndent}${srcBranch} s3://${config.srcBucket}/${src.key} (${src.bytes} bytes)\n`
+                `${sourceIndent}${srcBranch} s3://${config.srcBucket}/${src.key} (${src.bytes} bytes)${rangeSuffix}\n`
               );
             }
           }

--- a/lib/s3-concat.ts
+++ b/lib/s3-concat.ts
@@ -1,11 +1,13 @@
 import * as s3Client from './s3/client';
 import { S3File } from './s3/file';
 import {
+  newPartCopyTask,
+  newPartTask,
   planedSplitFile as planedSplitFiles,
   planedUploadTask,
   type UploadTask,
 } from './s3/task';
-import pLimit from './std/concurrency';
+import pLimit, { type LimitFunction } from './std/concurrency';
 import { Deque } from './std/deque';
 import {
   type StorageSize,
@@ -48,7 +50,13 @@ export type PlannedPart =
       kind: 'Part';
       partNumber: number;
       size: number;
-      sources: { key: string; bytes: number }[];
+      /**
+       * Sources read sequentially via `GetObject` and coalesced into one
+       * upload. `rangeStart` is the byte offset within the source; for most
+       * sources it is `0`, but the first source of a Part right after a
+       * `PartCopy` ate the file's head will have a non-zero `rangeStart`.
+       */
+      sources: { key: string; rangeStart: number; bytes: number }[];
     };
 
 export type PlannedOutput = {
@@ -57,16 +65,53 @@ export type PlannedOutput = {
   parts: PlannedPart[];
 };
 
+export type Plan = {
+  kind: 'planned';
+  srcBucketName: string;
+  dstBucketName: string;
+  totalFiles: number;
+  totalBytes: number;
+  skippedEmptyKeys: string[];
+  outputs: PlannedOutput[];
+};
+
 export type PlanResult =
-  | {
-      kind: 'plan';
-      totalFiles: number;
-      totalBytes: number;
-      skippedEmptyKeys: string[];
-      outputs: PlannedOutput[];
-    }
+  | Plan
   | { kind: 'fileNotFound' }
   | { kind: 'allEmpty'; emptyKeys: string[] };
+
+export type ExecutePlanParams = {
+  /**
+   * The S3 client to use for operations.
+   */
+  s3Client: S3Client;
+  /**
+   * The maximum number of concurrent asynchronous I/O operations.
+   * @default 5
+   */
+  pLimit?: number;
+  /**
+   * When `true`, pre-flight `HeadObject` every source key referenced by the
+   * plan and verify each object still has at least the byte range the plan
+   * needs. If any key is missing or has shrunk, the call rejects with a
+   * drift error before any multipart upload is created.
+   *
+   * When `false` (the default), `executePlan` skips the check and dispatches
+   * uploads immediately. The plan is assumed to be a faithful snapshot of
+   * the source bucket — if a referenced object was deleted or truncated
+   * since `plan()` ran, behavior depends on the part type: `UploadPartCopy`
+   * surfaces the S3 error promptly, but a streaming `Part` (sources < 5 MiB
+   * or trailing bytes of larger files) may hang up to the SDK's stream
+   * timeout and surface an unhandled rejection.
+   *
+   * Set this to `true` for any flow where the plan→execute gap is
+   * non-trivial (Step Functions Wait state, Slack approval, source buckets
+   * with lifecycle rules).
+   *
+   * @default false
+   */
+  check?: boolean;
+};
 
 export type ConcatParams = {
   /**
@@ -274,6 +319,7 @@ export class S3Concat {
         }
         const sources = task.s3Files.map((f) => ({
           key: f.key,
+          rangeStart: f.start,
           bytes: f.remainSize(),
         }));
         const size = sources.reduce((acc, s) => acc + s.bytes, 0);
@@ -287,7 +333,9 @@ export class S3Concat {
     });
 
     return {
-      kind: 'plan',
+      kind: 'planned',
+      srcBucketName: this.srcBucketName,
+      dstBucketName: this.dstBucketName,
       totalFiles: nonEmpty.length,
       totalBytes,
       skippedEmptyKeys: emptyKeys,
@@ -296,69 +344,134 @@ export class S3Concat {
   }
 
   async concat(): Promise<ConcatResult> {
-    if (this.s3Files.length === 0) {
-      return { kind: 'fileNotFound' };
+    const planResult = this.plan();
+    if (planResult.kind !== 'planned') {
+      return planResult;
     }
 
-    const emptyKeys: string[] = [];
-    const nonEmpty: S3FileMeta[] = [];
-    for (const f of this.s3Files) {
-      if (f.size === 0) {
-        emptyKeys.push(f.key);
-      } else {
-        nonEmpty.push(f);
-      }
-    }
-
-    if (nonEmpty.length === 0) {
-      return { kind: 'allEmpty', emptyKeys };
-    }
-
-    const s3Files = this.toS3Files(nonEmpty);
-    const splitFiles = planedSplitFiles(
-      this.concatFileNameCallback,
-      s3Files,
-      this.minSize
-    );
-
-    const splitFileAndUploadTask: {
-      keyName: string;
-      uploadTasks: UploadTask[];
-      size: number;
-    }[] = splitFiles.map((splitFile) => ({
-      keyName: splitFile.keyName,
-      uploadTasks: planedUploadTask(splitFile.s3Files.files),
-      size: splitFile.s3Files.size,
-    }));
-
-    // One shared semaphore caps the total in-flight S3 I/O across every
-    // output file. This replaces the v1.x "outer pLimit × inner pLimit"
-    // design, which let the effective concurrency reach pLimit² and made
-    // memory pressure scale with output count instead of just `pLimit`.
-    const limit = pLimit(this.limitConcurrency);
-
-    const keys = await Promise.all(
-      splitFileAndUploadTask.map(async (task) => {
-        const key = `${this.dstKey}/${task.keyName}`;
-        await s3Client.concatWithMultipartUpload(
-          this.s3Client,
-          this.srcBucketName,
-          this.dstBucketName,
-          key,
-          task.uploadTasks,
-          limit
-        );
-        return {
-          key,
-          size: task.size,
-        };
-      })
-    );
+    const keys = await S3Concat.executePlan(planResult, {
+      s3Client: this.s3Client,
+      pLimit: this.limitConcurrency,
+    });
 
     return {
       kind: 'concatenated',
       keys,
-      skippedEmptyKeys: emptyKeys,
+      skippedEmptyKeys: planResult.skippedEmptyKeys,
     };
   }
+
+  /**
+   * Execute a previously computed {@link Plan} without re-listing source
+   * objects. The plan is self-contained — `srcBucketName` and `dstBucketName`
+   * are read from the plan itself, and the source keys / byte ranges encoded
+   * in `parts` are used as-is.
+   *
+   * Source drift is **not** validated upfront. If a source key has been
+   * deleted or its size changed since {@link S3Concat.plan} ran, the underlying
+   * S3 API call (`UploadPartCopy` / `GetObject`) throws and the error is
+   * propagated. Decide on retry / re-plan at the caller.
+   *
+   * The destination keys are taken verbatim from `plan.outputs[].key` —
+   * `dstPrefix` is already baked in.
+   */
+  static async executePlan(
+    plan: Plan,
+    params: ExecutePlanParams
+  ): Promise<{ key: string; size: number }[]> {
+    const limitConcurrency = params.pLimit ?? DEFAULT_LIMIT_CONCURRENCY;
+    // One shared semaphore caps the total in-flight S3 I/O across every
+    // output file (same design as `concat()`).
+    const limit = pLimit(limitConcurrency);
+
+    if (params.check === true) {
+      await verifyPlanSources(
+        params.s3Client,
+        plan.srcBucketName,
+        collectRequiredBytes(plan),
+        limit
+      );
+    }
+
+    return Promise.all(
+      plan.outputs.map(async (output) => {
+        const uploadTasks = output.parts.map(toUploadTask);
+        await s3Client.concatWithMultipartUpload(
+          params.s3Client,
+          plan.srcBucketName,
+          plan.dstBucketName,
+          output.key,
+          uploadTasks,
+          limit
+        );
+        return { key: output.key, size: output.size };
+      })
+    );
+  }
 }
+
+const collectRequiredBytes = (plan: Plan): Map<string, number> => {
+  const required = new Map<string, number>();
+  const bump = (key: string, value: number): void => {
+    const prev = required.get(key) ?? 0;
+    if (value > prev) required.set(key, value);
+  };
+  for (const output of plan.outputs) {
+    for (const part of output.parts) {
+      if (part.kind === 'PartCopy') {
+        bump(part.source.key, part.source.rangeEnd);
+      } else {
+        for (const s of part.sources) {
+          bump(s.key, s.rangeStart + s.bytes);
+        }
+      }
+    }
+  }
+  return required;
+};
+
+const verifyPlanSources = async (
+  client: S3Client,
+  bucket: string,
+  required: Map<string, number>,
+  limit: LimitFunction
+): Promise<void> => {
+  const drift: string[] = [];
+  await Promise.all(
+    [...required.entries()].map(([key, requiredBytes]) =>
+      limit(async () => {
+        const size = await s3Client.headObjectSize(client, bucket, key);
+        if (size === undefined) {
+          drift.push(`missing s3://${bucket}/${key}`);
+        } else if (size < requiredBytes) {
+          drift.push(
+            `truncated s3://${bucket}/${key} (size ${size}, plan needs ${requiredBytes})`
+          );
+        }
+      })
+    )
+  );
+  if (drift.length > 0) {
+    throw new Error(`plan drift detected: ${drift.join('; ')}`);
+  }
+};
+
+const toUploadTask = (part: PlannedPart): UploadTask => {
+  if (part.kind === 'PartCopy') {
+    // S3File.size is only consulted by code that walks remainSize(); for
+    // PartCopy the executor only reads .key / .start / .end, so any size that
+    // satisfies `start <= size` works. Use the range end to keep invariants.
+    return newPartCopyTask(
+      new S3File(part.source.key, part.source.rangeEnd, part.source.rangeStart),
+      part.source.rangeStart,
+      part.source.rangeEnd
+    );
+  }
+  // buildMergedBody reads `bytes=${start}-${size - 1}`, so size must equal
+  // `start + bytes` to drain exactly `bytes` from the source.
+  return newPartTask(
+    part.sources.map(
+      (s) => new S3File(s.key, s.rangeStart + s.bytes, s.rangeStart)
+    )
+  );
+};

--- a/lib/s3/client.ts
+++ b/lib/s3/client.ts
@@ -4,6 +4,7 @@ import {
   type CompletedPart,
   CompleteMultipartUploadCommand,
   CreateMultipartUploadCommand,
+  HeadObjectCommand,
   ListObjectsV2Command,
   type ListObjectsV2CommandOutput,
   UploadPartCommand,
@@ -62,6 +63,31 @@ export const getListFiles = async (
   } while (continuationToken !== undefined);
 
   return fileList;
+};
+
+/**
+ * Returns the ContentLength of the object, or `undefined` if it does not
+ * exist. Any other error (permissions, throttling, network) is rethrown.
+ */
+export const headObjectSize = async (
+  s3Client: S3Client,
+  bucketName: string,
+  key: string
+): Promise<number | undefined> => {
+  try {
+    const res = await s3Client.send(
+      new HeadObjectCommand({ Bucket: bucketName, Key: key })
+    );
+    return res.ContentLength;
+  } catch (err) {
+    const name = (err as { name?: string }).name;
+    // S3 returns 404 NotFound for HeadObject on a missing key; SDK exposes
+    // it as either NotFound (most paths) or NoSuchKey (some legacy paths).
+    if (name === 'NotFound' || name === 'NoSuchKey') {
+      return undefined;
+    }
+    throw err;
+  }
 };
 
 const encodeCopySourceKey = (key: string): string =>

--- a/tests/medium/s3-concat.test.ts
+++ b/tests/medium/s3-concat.test.ts
@@ -1,6 +1,10 @@
-import { GetObjectCommand, ListObjectsV2Command } from '@aws-sdk/client-s3';
+import {
+  DeleteObjectCommand,
+  GetObjectCommand,
+  ListObjectsV2Command,
+} from '@aws-sdk/client-s3';
 import { inject } from 'vitest';
-import { S3Concat } from '../../lib/s3-concat';
+import { type Plan, S3Concat } from '../../lib/s3-concat';
 import { KiB, MiB } from '../../lib/std/storage-size';
 import { createTestS3Client } from '../helpers/s3-client-factory';
 import { S3ClientHelper } from '../helpers/s3-helper';
@@ -587,5 +591,206 @@ describe('concat', () => {
         StorageClass: 'STANDARD',
       }),
     ]);
+  });
+});
+
+describe('S3Concat.executePlan', () => {
+  describe('when replaying a plan through JSON round-trip', () => {
+    test('writes a destination object equal to the literal expected bytes', async () => {
+      // Given: source has 2 files of 1024000 bytes 'A' and 1 file of 5242880
+      // bytes 'B'. keyNameAsc places them as file-1-1, file-1-2, file-2-1.
+      const files = [
+        { fileSize: 1024000, fileCount: 2, fill: 'A' },
+        { fileSize: 5242880, fileCount: 1, fill: 'B' },
+      ];
+      const prefix = 'tmp';
+      const dstPrefix = 'output';
+      const s3Client = createTestS3Client(TEST_S3_CONFIG);
+      const s3ClientHelper = new S3ClientHelper(s3Client);
+      const { bucketName } = await s3ClientHelper.setupS3({ files, prefix });
+
+      const s3Concat = new S3Concat({
+        s3Client,
+        srcBucketName: bucketName,
+        dstBucketName: bucketName,
+        dstPrefix,
+        concatFileName: 'replayed.bin',
+        joinOrder: 'keyNameAsc',
+      });
+      await s3Concat.addFiles(prefix);
+
+      // When: plan -> JSON.stringify/parse -> executePlan.
+      const planResult = s3Concat.plan();
+      if (planResult.kind !== 'planned') throw new Error('expected plan');
+      const restored = JSON.parse(JSON.stringify(planResult)) as Plan;
+      const executed = await S3Concat.executePlan(restored, { s3Client });
+
+      // Then: result + destination bytes match literal expected (2 * 1024000
+      // 'A' followed by 5242880 'B' = 7290880 bytes total).
+      expect(executed).toEqual([
+        { key: `${dstPrefix}/replayed.bin`, size: 7290880 },
+      ]);
+      const got = await s3Client.send(
+        new GetObjectCommand({
+          Bucket: bucketName,
+          Key: `${dstPrefix}/replayed.bin`,
+        })
+      );
+      const body = await got.Body?.transformToByteArray();
+      const expected = Buffer.concat([
+        Buffer.alloc(2048000, 'A'),
+        Buffer.alloc(5242880, 'B'),
+      ]);
+      expect(body).toEqual(new Uint8Array(expected));
+    });
+  });
+
+  describe('when a Part source has rangeStart > 0 (post-PartCopy tail)', () => {
+    test('reads from the recorded offset, not from byte 0', async () => {
+      // Given: a 10 MiB source object made of 5242880 'A' then 5242880 'B',
+      // and a hand-crafted plan whose only Part references that source at
+      // rangeStart=5242880 for bytes=5242880. (This is the shape concat()
+      // produces after a PartCopy eats a file's head; constructed directly
+      // here so the test does not need a 5 GiB+ object.)
+      const prefix = 'tmp';
+      const dstPrefix = 'output';
+      const sourceKey = `${prefix}/half-half.bin`;
+      const outputKey = `${dstPrefix}/tail.bin`;
+      const s3Client = createTestS3Client(TEST_S3_CONFIG);
+      const s3ClientHelper = new S3ClientHelper(s3Client);
+      const { bucketName } = await s3ClientHelper.setupS3({
+        files: [],
+        prefix,
+      });
+      await s3ClientHelper.uploadFile(
+        bucketName,
+        sourceKey,
+        Buffer.concat([Buffer.alloc(5242880, 'A'), Buffer.alloc(5242880, 'B')])
+      );
+
+      const plan: Plan = {
+        kind: 'planned',
+        srcBucketName: bucketName,
+        dstBucketName: bucketName,
+        totalFiles: 1,
+        totalBytes: 5242880,
+        skippedEmptyKeys: [],
+        outputs: [
+          {
+            key: outputKey,
+            size: 5242880,
+            parts: [
+              {
+                kind: 'Part',
+                partNumber: 1,
+                size: 5242880,
+                sources: [
+                  { key: sourceKey, rangeStart: 5242880, bytes: 5242880 },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      // When: executePlan replays the plan.
+      await S3Concat.executePlan(plan, { s3Client });
+
+      // Then: destination is 5242880 bytes of 'B' (the second half). If
+      // rangeStart were ignored the output would be all 'A'.
+      const got = await s3Client.send(
+        new GetObjectCommand({ Bucket: bucketName, Key: outputKey })
+      );
+      const body = await got.Body?.transformToByteArray();
+      expect(body).toEqual(new Uint8Array(Buffer.alloc(5242880, 'B')));
+    });
+  });
+
+  describe('with check: true', () => {
+    describe('when a referenced source has been deleted since plan() ran', () => {
+      test('rejects with a missing diagnostic well under the streaming-body hang window', async () => {
+        // Given: small files force the streaming Part path (sources < 5 MiB).
+        // Without check:true a missing source would hang the GetObject ->
+        // UploadPart pipeline for ~60s before throwing.
+        const files = [{ fileSize: 1000 * KiB, fileCount: 3 }];
+        const prefix = 'tmp';
+        const dstPrefix = 'output';
+        const s3Client = createTestS3Client(TEST_S3_CONFIG);
+        const s3ClientHelper = new S3ClientHelper(s3Client);
+        const { bucketName } = await s3ClientHelper.setupS3({
+          files,
+          prefix,
+        });
+
+        const s3Concat = new S3Concat({
+          s3Client,
+          srcBucketName: bucketName,
+          dstBucketName: bucketName,
+          dstPrefix,
+          concatFileName: 'merged.bin',
+        });
+        await s3Concat.addFiles(prefix);
+        const planResult = s3Concat.plan();
+        if (planResult.kind !== 'planned') throw new Error('expected plan');
+        const victimKey = `${prefix}/file-1-2.txt`;
+        await s3Client.send(
+          new DeleteObjectCommand({ Bucket: bucketName, Key: victimKey })
+        );
+
+        // When: executePlan with check:true runs after the source is deleted.
+        const start = performance.now();
+        const result = expect(
+          S3Concat.executePlan(planResult, { s3Client, check: true })
+        ).rejects.toThrow(
+          new RegExp(`missing s3://${bucketName}/${victimKey}`)
+        );
+        await result;
+        const elapsed = performance.now() - start;
+
+        // Then: rejection arrives via pre-flight HeadObject, not via the
+        // streaming-body timeout — i.e. fast enough to be safe inside a
+        // Lambda runtime.
+        expect(elapsed).toBeLessThan(10_000);
+      });
+    });
+
+    describe('when a referenced source has been truncated since plan() ran', () => {
+      test('rejects with a truncated diagnostic', async () => {
+        // Given: a 6 MiB source overwritten with a 1 KiB stub so the plan
+        // refers to byte ranges that no longer exist.
+        const files = [{ fileSize: 6 * MiB, fileCount: 2 }];
+        const prefix = 'tmp';
+        const dstPrefix = 'output';
+        const s3Client = createTestS3Client(TEST_S3_CONFIG);
+        const s3ClientHelper = new S3ClientHelper(s3Client);
+        const { bucketName } = await s3ClientHelper.setupS3({
+          files,
+          prefix,
+        });
+
+        const s3Concat = new S3Concat({
+          s3Client,
+          srcBucketName: bucketName,
+          dstBucketName: bucketName,
+          dstPrefix,
+          concatFileName: 'merged.bin',
+        });
+        await s3Concat.addFiles(prefix);
+        const planResult = s3Concat.plan();
+        if (planResult.kind !== 'planned') throw new Error('expected plan');
+        const victimKey = `${prefix}/file-1-1.txt`;
+        await s3ClientHelper.uploadFile(
+          bucketName,
+          victimKey,
+          Buffer.alloc(1 * KiB, '0')
+        );
+
+        // When: executePlan with check:true runs against the truncated source.
+        // Then: pre-flight detects the shrinkage and rejects.
+        await expect(
+          S3Concat.executePlan(planResult, { s3Client, check: true })
+        ).rejects.toThrow(/truncated/);
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Add `S3Concat.executePlan(plan, params)` static method so a plan built by `plan()` can be persisted as a checkpoint and replayed later by a different step / process — designed for AWS Lambda Durable Functions, Step Functions Wait states, Slack approval flows, and similar split orchestrations.
- The `Plan` type is now a self-contained, JSON-serializable spec (carries `srcBucketName` / `dstBucketName`; `PlannedPart.Part.sources[]` now carries `rangeStart` so post-PartCopy tail bytes round-trip correctly).
- `ExecutePlanParams.check` (default `false`) opts in to a parallel `HeadObject` pre-flight that rejects up-front on missing or shrunk sources, before any multipart upload is created. Use it whenever the source bucket may be mutated between `plan()` and `executePlan()`.

## Why

This addresses user feedback (Athena UNLOAD → Lambda concat pipeline) asking for a way to share a plan between Durable Functions `context.step()` calls without re-running `ListObjectsV2` and without the risk that the second call sees a different source set. The Plan is now a faithful snapshot the user can JSON-encode, log for human review, or hand to an approval flow.

The `check` option exists because without pre-flight, drift on a streaming `Part` source (< 5 MiB) stalls `UploadPart` on the SDK's stream timeout with an unhandled `Promise` rejection — bad failure mode for a long-running Lambda. `check: true` rejects in milliseconds via HeadObject instead.

## Public API changes

- New type: `Plan` (= `Extract<PlanResult, {kind: 'planned'}>`), `ExecutePlanParams`.
- `PlanResult` success discriminator renamed: `kind: 'plan'` → `kind: 'planned'` (consistency with `ConcatResult.kind === 'concatenated'`).
- `PlannedPart.Part.sources[]` shape changed: `{key, bytes}` → `{key, rangeStart, bytes}`. Required for correct GetObject Range reconstruction on the tail-source case.
- `S3Concat.plan()` return now includes `srcBucketName` / `dstBucketName`.
- New: `S3Concat.executePlan(plan, params)` static method.
- `concat()` is unchanged from the caller's perspective — internally it now delegates to `plan() + executePlan()` to avoid duplicate logic.


