### PR TITLE
refactor: fix typo and drop dead cspell entries

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -4,7 +4,6 @@
     "deque",
     "esbuild",
     "floci",
-    "localstack",
     "pnpm",
     "protobufjs",
     "shuntaka",
@@ -18,13 +17,5 @@
     "coverage",
     "pnpm-lock.yaml",
     "package-lock.json"
-  ],
-  "ignoreRegExpList": [""],
-  "languageSettings": [
-    {
-      "languageId": "*",
-      "dictionaries": [],
-      "dictionaryDefinitions": []
-    }
   ]
 }

--- a/lib/s3-concat.ts
+++ b/lib/s3-concat.ts
@@ -3,8 +3,8 @@ import { S3File } from './s3/file';
 import {
   newPartCopyTask,
   newPartTask,
-  planedSplitFile as planedSplitFiles,
-  planedUploadTask,
+  plannedSplitFiles,
+  plannedUploadTasks,
   type UploadTask,
 } from './s3/task';
 import pLimit, { type LimitFunction } from './std/concurrency';
@@ -295,14 +295,14 @@ export class S3Concat {
     }
 
     const s3Files = this.toS3Files(nonEmpty);
-    const splitFiles = planedSplitFiles(
+    const splitFiles = plannedSplitFiles(
       this.concatFileNameCallback,
       s3Files,
       this.minSize
     );
 
     const outputs: PlannedOutput[] = splitFiles.map((sf) => {
-      const tasks = planedUploadTask(sf.s3Files.files);
+      const tasks = plannedUploadTasks(sf.s3Files.files);
       const parts: PlannedPart[] = tasks.map((task, idx) => {
         const partNumber = idx + 1;
         if (task.uploadType === 'PartCopy') {

--- a/lib/s3/task.ts
+++ b/lib/s3/task.ts
@@ -37,7 +37,7 @@ type SplitGroup = {
   s3Files: { files: Deque<S3File>; size: number };
 };
 
-export const planedSplitFile = (
+export const plannedSplitFiles = (
   concatFileNameCallback: (idx?: number) => string,
   s3Files: { files: Deque<S3File>; size: number },
   minValue?: number
@@ -151,7 +151,7 @@ const planSmallFilePart = (
   tasks.push(partTask);
 };
 
-export const planedUploadTask = (s3Files: Deque<S3File>): UploadTask[] => {
+export const plannedUploadTasks = (s3Files: Deque<S3File>): UploadTask[] => {
   const tasks: UploadTask[] = [];
 
   while (s3Files.size > 0) {


### PR DESCRIPTION
## Summary

- Rename internal helpers `planedSplitFile` / `planedUploadTask` to `plannedSplitFiles` / `plannedUploadTasks` to fix the "planed" typo and pluralize to match their array return types.
- Drop dead entries from `cspell.json`: the empty-string `ignoreRegExpList` entry (matches every position, has no useful effect), the no-op `languageSettings` block, and the unused `localstack` word.

## Changes

- `lib/s3/task.ts`: rename exported helpers `planedSplitFile` → `plannedSplitFiles` and `planedUploadTask` → `plannedUploadTasks`.
- `lib/s3-concat.ts`: update imports/callers; drop the previous `as planedSplitFiles` alias and import the renamed names directly.
- `cspell.json`: remove `ignoreRegExpList: [""]`, remove the empty `languageSettings` block, and remove the unused `localstack` word from `words`.

No public API change — both renamed functions live in `lib/` internals and are not re-exported from the package entry point.

## Test plan

- [x] `pnpm check` (lint / format / type / spell) passes
- [x] `pnpm test` (vitest, 35 tests) passes
