### PR TITLE
chore: tune Renovate to batch aws-sdk weekly and disable lockfile maintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
     "schedule": ["at any time"]
   },
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": false
   },
   "packageRules": [
     {
@@ -30,9 +30,11 @@
       "groupName": "github-actions"
     },
     {
-      "description": "Group AWS SDK packages",
+      "description": "Group AWS SDK packages and batch weekly",
       "matchPackageNames": ["@aws-sdk/**"],
-      "groupName": "aws-sdk"
+      "groupName": "aws-sdk",
+      "schedule": ["before 4am on monday"],
+      "minimumReleaseAge": "1 day"
     },
     {
       "description": "Widen Node engines range instead of bumping the floor",


### PR DESCRIPTION
## Summary

- Disable `lockFileMaintenance` — transitive dep vulnerabilities are covered by Dependabot Alerts + `vulnerabilityAlerts`, so the weekly lockfile-refresh PR (e.g. #46) was pure noise.
- Batch `@aws-sdk/*` updates into one weekly PR (`before 4am on monday`) so the near-daily AWS SDK releases collapse into a single review instead of several PRs throughout the week.
- Drop `minimumReleaseAge` to `1 day` for the AWS SDK group so the Monday batch can still pick up versions published the previous day; everything else keeps the 3-day default.

## Background

Verified against npm publish times that the global `minimumReleaseAge: 3 days` was already being honored — every recent AWS SDK PR was created within minutes of the 3-day mark. The actual pain was the *rate* of PRs, not the wait, because the AWS SDK ships nearly every day. Batching by schedule fixes that directly.

