### PR TITLE
ci: test against Node.js 22/24/26 matrix

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -1,6 +1,12 @@
 name: action ci
 description: Install dependencies, run checks, and execute the test suite.
 
+inputs:
+  node-version:
+    description: Node.js version to install. Falls back to .node-version when empty.
+    required: false
+    default: ''
+
 runs:
   using: 'composite'
   steps:
@@ -10,7 +16,8 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version-file: './.node-version'
+        node-version: ${{ inputs.node-version }}
+        node-version-file: ${{ inputs.node-version == '' && './.node-version' || '' }}
         cache: 'pnpm'
         registry-url: 'https://registry.npmjs.org/'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: ci
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 permissions: {}
@@ -12,6 +13,10 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['22', '24', '26']
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -20,8 +25,11 @@ jobs:
 
       - name: Action ci
         uses: ./.github/actions/ci
+        with:
+          node-version: ${{ matrix.node-version }}
 
       - name: Upload coverage reports to Codecov
+        if: matrix.node-version == '26'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./coverage/coverage-final.json

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "nodejs"
   ],
   "engines": {
-    "node": ">=22.22.3 <25"
+    "node": ">=22.22.3 <27"
   },
   "release": {
     "branches": [


### PR DESCRIPTION
## Summary
- Extend supported Node.js range to include Node 26 (`engines.node`: `>=22.22.3 <27`).
- Run `ci` as a matrix across Node.js 22, 24, and 26 so each supported major is exercised.
- Restrict the workflow `push` trigger to `main` to avoid duplicate runs on PR branches.

## Changes
### `package.json`
- Bumped `engines.node` upper bound from `<25` to `<27` so Node 25/26 are no longer rejected.

### `.github/actions/ci/action.yml`
- Added a `node-version` input (defaults to empty string).
- `actions/setup-node` now uses the input when provided, otherwise falls back to `./.node-version`. This keeps `release.yml` working without any change.

### `.github/workflows/ci.yml`
- Added `strategy.matrix.node-version: ['22', '24', '26']` with `fail-fast: false`.
- Passed `node-version` through to the composite action.
- Limited the `push` trigger to `branches: [main]` to remove duplicate `push` + `pull_request` runs on PR branches.
- Codecov upload now only runs on the `26` job to avoid duplicate uploads.

## Notes
- Versions are hardcoded in the workflow rather than fetched at runtime to minimize the CI supply-chain attack surface.
- Job names change to `ci (22)` / `ci (24)` / `ci (26)`. If the default branch protection requires `ci` as a status check, it needs to be re-configured to require the matrix jobs instead.

## Test plan
- [ ] `ci (22)`, `ci (24)`, `ci (26)` all pass on this PR.
- [ ] Codecov upload runs only on `ci (26)`.
- [ ] After merging, `release.yml` still uses `.node-version` (24.x) and publishes successfully on the next release.
